### PR TITLE
Offload CLI argument parsing to Taywee/args

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Dependencies/args"]
+	path = Dependencies/args
+	url = https://github.com/Taywee/args

--- a/Src/Processor/CMakeLists.txt
+++ b/Src/Processor/CMakeLists.txt
@@ -96,12 +96,14 @@ set(HEADERS
 include_directories(${SHARED})
 
 # Add external include directories
-include_directories(${EXTERNAL}/MySQL/include)
+include_directories(${EXTERNAL}/args)
 include_directories(${EXTERNAL}/curl/include)
+include_directories(${EXTERNAL}/MySQL/include)
 include_directories(${EXTERNAL}/StrFormat)
 
-link_directories(${EXTERNAL}/MySQL/lib)
+# External library directories
 link_directories(${EXTERNAL}/curl/lib)
+link_directories(${EXTERNAL}/MySQL/lib)
 
 if (WIN32)
 	set(LIBRARIES

--- a/Src/Processor/main.cpp
+++ b/Src/Processor/main.cpp
@@ -6,26 +6,6 @@
 using namespace std::chrono;
 using namespace SharedEnums;
 
-void WrapperProcess(std::string executableName, EGamemode gamemode, bool ReProcess)
-{
-#ifdef __WIN32
-	auto ExecutionCommand = StrFormat("{0} -f -m {1}", executableName, gamemode);
-#else
-	auto ExecutionCommand = StrFormat("./{0} -f -m {1}", executableName, gamemode);
-#endif
-
-	if(ReProcess)
-		ExecutionCommand += " -r";
-
-	while(true)
-	{
-		static const int RestartDelay = 5;
-		int ErrorCode = system(ExecutionCommand.c_str());
-		Log(ErrorCode != 0 ? CLog::Error : CLog::Info, StrFormat("Program terminated with error code {0}. Restarting in {1} seconds.", ErrorCode, RestartDelay));
-		std::this_thread::sleep_for(seconds{RestartDelay});
-	}
-}
-
 int main(s32 argc, char* argv[])
 {
 	srand(static_cast<unsigned int>(time(NULL)));
@@ -68,14 +48,6 @@ int main(s32 argc, char* argv[])
 		}
 	}
 
-	// If there is no force parameter, then we are a wrapper process, ensuring, that there will always be an actual process running
-	// This is no excuse for poor exception handling - but a worst-case measure to prevent downtime.
-	// TODO: Proper logging of crashes, including core dumps
-	if(!Force)
-	{
-		WrapperProcess(argv[0], Gamemode, ReProcess);
-		return 0;
-	}
 
 	try
 	{

--- a/Src/Processor/main.cpp
+++ b/Src/Processor/main.cpp
@@ -3,6 +3,8 @@
 #include "Processor.h"
 #include "SharedEnums.h"
 
+#include <args.hxx>
+
 using namespace std::chrono;
 using namespace SharedEnums;
 
@@ -20,39 +22,84 @@ int main(s32 argc, char* argv[])
 	}
 #endif
 
-	bool Force = false;
-	bool ReProcess = false;
-	EGamemode Gamemode = EGamemode::Standard;
-
-	// Process arguments. Can ignore first one which is the executable name
-	for(s32 i = 1; i < argc; ++i)
+	std::vector<std::string> arguments;
+	for(int i = 1; i < argc; ++i)
 	{
-		if(std::string{"-f"} == argv[i])
-			Force = true;
-
-		if(std::string{"-r"} == argv[i])
-			ReProcess = true;
-
-		if(std::string{"-m"} == argv[i])
-		{
-			++i;
-
-			// An errornous input... better report
-			if(i >= argc)
-			{
-				Log(CLog::Error, "Missing mode specifier after \"-m\".");
-				return 0;
-			}
-
-			Gamemode = static_cast<EGamemode>(std::atoi(argv[i]));
-		}
+		std::string arg = argv[i];
+		// macOS sometimes (seemingly sporadically) passes the
+		// process serial number via a command line parameter.
+		// We would like to ignore this.
+		if (arg.find("-psn") != 0)
+			arguments.emplace_back(argv[i]);
 	}
 
+	args::ArgumentParser Parser{
+		"Computes performance points (pp) for the rhythm game osu!",
+		"",
+	};
+
+	args::HelpFlag HelpFlag{
+		Parser,
+		"help",
+		"Display this help menu",
+		{'h', "help"},
+	};
+
+	args::Flag RecomputeFlag{
+		Parser,
+		"recompute",
+		"Forces recomputation of pp for all players. Useful if the underlying algorithm changed.",
+		{'r', "recompute"},
+	};
+
+	args::ValueFlag<u32> ModeFlag{
+		Parser,
+		"mode",
+		"The game mode to compute pp for.",
+		{'m', "mode"},
+	};
+
+	// Parse command line arguments and react to parsing
+	// errors using exceptions.
+	try
+	{
+		Parser.ParseArgs(arguments);
+	}
+	catch(args::Help)
+	{
+		std::cout << Parser;
+		return 0;
+	}
+	catch(args::ParseError e)
+	{
+		std::cerr << e.what() << std::endl;
+		std::cerr << Parser;
+		return -1;
+	}
+	catch(args::ValidationError e)
+	{
+		std::cerr << e.what() << std::endl;
+		std::cerr << Parser;
+		return -2;
+	}
 
 	try
 	{
+		EGamemode Gamemode = EGamemode::Standard;
+		if(ModeFlag)
+		{
+			u32 ModeId = args::get(ModeFlag);
+			if(ModeId < EGamemode::AmountGamemodes)
+				Gamemode = (EGamemode)ModeId;
+			else
+				throw CLoggedException(SRC_POS, StrFormat("Invalid gamemode ID {0} supplied.", ModeId));
+		}
+
 		// Create game object
-		CProcessor Processor{Gamemode, ReProcess};
+		CProcessor Processor{
+			Gamemode,
+			RecomputeFlag,
+		};
 	}
 	catch(CLoggedException& e)
 	{


### PR DESCRIPTION
- Offloads CLI argument parsing to Taywee/args
   - I've used this single-header library in some of my own projects and it works really well
   - In the future we will need support for positional arguments to supply a list of users to compute. This dependency will handle it.
- Removes the wrapper functionality (absence of `-f` flag). We really should be using the `watch` tool instead.