### PR TITLE
Allow computing PP of specific users via CLI

### DIFF
--- a/Src/Processor/Beatmap.h
+++ b/Src/Processor/Beatmap.h
@@ -40,12 +40,12 @@ public:
 
 	ERankedStatus RankedStatus() const { return _rankedStatus; }
 	EScoreVersion ScoreVersion() const { return _scoreVersion; }
-	s32 AmountHitCircles() const { return _amountHitCircles; }
+	s32 NumHitCircles() const { return _numHitCircles; }
 	f32 DifficultyAttribute(EMods mods, EDifficultyAttributeType type) const;
 
 	void SetRankedStatus(ERankedStatus rankedStatus) { _rankedStatus = rankedStatus; }
 	void SetScoreVersion(EScoreVersion scoreVersion) { _scoreVersion = scoreVersion; }
-	void SetAmountHitCircles(s32 amountHitCircles) { _amountHitCircles = amountHitCircles; }
+	void SetNumHitCircles(s32 numHitCircles) { _numHitCircles = numHitCircles; }
 	void SetDifficultyAttribute(EMods mods, EDifficultyAttributeType type, f32 value);
 
 	static EDifficultyAttributeType DifficultyAttributeFromName(const std::string& difficultyAttributeName)
@@ -83,5 +83,5 @@ private:
 	// Additional info required for processor
 	ERankedStatus _rankedStatus;
 	EScoreVersion _scoreVersion;
-	s32 _amountHitCircles = 0;
+	s32 _numHitCircles = 0;
 };

--- a/Src/Processor/CatchTheBeat/CatchTheBeatScore.cpp
+++ b/Src/Processor/CatchTheBeat/CatchTheBeatScore.cpp
@@ -10,15 +10,15 @@ CCatchTheBeatScore::CCatchTheBeatScore(
 	s32 beatmapId,
 	s32 score,
 	s32 maxCombo,
-	s32 amount300,
-	s32 amount100,
-	s32 amount50,
-	s32 amountMiss,
-	s32 amountGeki,
-	s32 amountKatu,
+	s32 num300,
+	s32 num100,
+	s32 num50,
+	s32 numMiss,
+	s32 numGeki,
+	s32 numKatu,
 	EMods mods,
 	const CBeatmap& beatmap
-) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, amount300, amount100, amount50, amountMiss, amountGeki, amountKatu, mods}
+) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
 {
 	// Don't count scores made with supposedly unranked mods
 	if ((_mods & EMods::Relax) > 0 ||
@@ -33,18 +33,18 @@ CCatchTheBeatScore::CCatchTheBeatScore(
 	_value = pow(5.0f * std::max(1.0f, beatmap.DifficultyAttribute(_mods, CBeatmap::Aim) / 0.0049f) - 4.0f, 2.0f) / 100000.0f;
 
 	// Longer maps are worth more. "Longer" means how many hits there are which can contribute to combo
-	int amountTotalHits = TotalComboHits();
+	int numTotalHits = TotalComboHits();
 
 	// Longer maps are worth more
 	f32 lengthBonus =
-		0.95f + 0.4f * std::min<f32>(1.0f, static_cast<f32>(amountTotalHits) / 3000.0f) +
-		(amountTotalHits > 3000 ? log10(static_cast<f32>(amountTotalHits) / 3000.0f) * 0.5f : 0.0f);
+		0.95f + 0.4f * std::min<f32>(1.0f, static_cast<f32>(numTotalHits) / 3000.0f) +
+		(numTotalHits > 3000 ? log10(static_cast<f32>(numTotalHits) / 3000.0f) * 0.5f : 0.0f);
 
 	// Longer maps are worth more
 	_value *= lengthBonus;
 
 	// Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
-	_value *= pow(0.97f, _amountMiss);
+	_value *= pow(0.97f, _numMiss);
 
 	// Combo scaling
 	float beatmapMaxCombo = beatmap.DifficultyAttribute(_mods, CBeatmap::MaxCombo);
@@ -94,15 +94,15 @@ f32 CCatchTheBeatScore::Accuracy() const
 
 s32 CCatchTheBeatScore::TotalHits() const
 {
-	return _amount50 + _amount100 + _amount300 + _amountMiss + _amountKatu;
+	return _num50 + _num100 + _num300 + _numMiss + _numKatu;
 }
 
 s32 CCatchTheBeatScore::TotalSuccessfulHits() const
 {
-	return _amount50 + _amount100 + _amount300;
+	return _num50 + _num100 + _num300;
 }
 
 s32 CCatchTheBeatScore::TotalComboHits() const
 {
-	return _amount300 + _amount100 + _amountMiss;
+	return _num300 + _num100 + _numMiss;
 }

--- a/Src/Processor/CatchTheBeat/CatchTheBeatScore.h
+++ b/Src/Processor/CatchTheBeat/CatchTheBeatScore.h
@@ -12,12 +12,12 @@ public:
 		s32 beatmapId,
 		s32 score,
 		s32 maxCombo,
-		s32 amount300,
-		s32 amount100,
-		s32 amount50,
-		s32 amountMiss,
-		s32 amountGeki,
-		s32 amountKatu,
+		s32 num300,
+		s32 num100,
+		s32 num50,
+		s32 numMiss,
+		s32 numGeki,
+		s32 numKatu,
 		EMods mods,
 		const CBeatmap& beatmap
 	);

--- a/Src/Processor/Mania/ManiaScore.cpp
+++ b/Src/Processor/Mania/ManiaScore.cpp
@@ -10,15 +10,15 @@ CManiaScore::CManiaScore(
 	s32 beatmapId,
 	s32 score,
 	s32 maxCombo,
-	s32 amount300,
-	s32 amount100,
-	s32 amount50,
-	s32 amountMiss,
-	s32 amountGeki,
-	s32 amountKatu,
+	s32 num300,
+	s32 num100,
+	s32 num50,
+	s32 numMiss,
+	s32 numGeki,
+	s32 numKatu,
 	EMods mods,
 	const CBeatmap& beatmap
-) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, amount300, amount100, amount50, amountMiss, amountGeki, amountKatu, mods}
+) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
 {
 	ComputeStrainValue(beatmap);
 	ComputeAccValue(beatmap);
@@ -118,16 +118,16 @@ f32 CManiaScore::Accuracy() const
 		return 0;
 
 	return
-		clamp(static_cast<f32>(_amount50 * 50 + _amount100 * 100 + _amountKatu * 200 + (_amount300 + _amountGeki) * 300)
+		clamp(static_cast<f32>(_num50 * 50 + _num100 * 100 + _numKatu * 200 + (_num300 + _numGeki) * 300)
 		/ (TotalHits() * 300), 0.0f, 1.0f);
 }
 
 s32 CManiaScore::TotalHits() const
 {
-	return _amount50 + _amount100 + _amount300 + _amountMiss + _amountGeki + _amountKatu;
+	return _num50 + _num100 + _num300 + _numMiss + _numGeki + _numKatu;
 }
 
 s32 CManiaScore::TotalSuccessfulHits() const
 {
-	return _amount50 + _amount100 + _amount300 + _amountGeki + _amountKatu;
+	return _num50 + _num100 + _num300 + _numGeki + _numKatu;
 }

--- a/Src/Processor/Mania/ManiaScore.h
+++ b/Src/Processor/Mania/ManiaScore.h
@@ -12,12 +12,12 @@ public:
 		s32 beatmapId,
 		s32 score,
 		s32 maxCombo,
-		s32 amount300,
-		s32 amount100,
-		s32 amount50,
-		s32 amountMiss,
-		s32 amountGeki,
-		s32 amountKatu,
+		s32 num300,
+		s32 num100,
+		s32 num50,
+		s32 numMiss,
+		s32 numGeki,
+		s32 numKatu,
 		EMods mods,
 		const CBeatmap& beatmap
 	);

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -218,8 +218,17 @@ void CProcessor::ProcessUsers(const std::vector<std::string>& userNames)
 		return 0ll;
 	};
 
-	std::vector<s64> userIds(userNames.size());
-	std::transform(std::begin(userNames), std::end(userNames), std::begin(userIds), userNameToId);
+	std::vector<s64> userIds;
+	for (const auto& name : userNames)
+	{
+		s64 id = xtoi64(name.c_str());
+		if (id == 0) {
+			// TODO: Allow querying IDs by name once it's available in the DB
+			continue;
+		}
+
+		userIds.emplace_back(id);
+	}
 
 	ProcessUsers(userIds);
 }

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -208,16 +208,6 @@ void CProcessor::ProcessAllUsers(bool reProcess, u32 numThreads)
 
 void CProcessor::ProcessUsers(const std::vector<std::string>& userNames)
 {
-	auto userNameToId = [](const std::string& name) {
-		s64 id = xtoi64(name.c_str());
-		if (id != 0) {
-			return id;
-		}
-
-		// TODO: Allow querying IDs by name once it's available in the DB
-		return 0ll;
-	};
-
 	std::vector<s64> userIds;
 	for (const auto& name : userNames)
 	{

--- a/Src/Processor/Processor.h
+++ b/Src/Processor/Processor.h
@@ -11,9 +11,6 @@
 
 DEFINE_LOGGED_EXCEPTION(CProcessorException);
 
-// Specify user id to test
-//#define PLAYER_TESTING 124493
-
 struct SScore;
 
 class CProcessor
@@ -40,6 +37,7 @@ public:
 	void MonitorNewScores();
 	void ProcessAllUsers(bool reProcess, u32 numThreads);
 	void ProcessUsers(const std::vector<std::string>& userNames);
+	void ProcessUsers(const std::vector<s64>& userIds);
 
 private:
 	static const std::array<const std::string, NumGamemodes> s_gamemodeSuffixes;
@@ -107,7 +105,7 @@ private:
 	void QueryBeatmapDifficultyAttributes();
 
 	// Not thread safe with beatmap data!
-	void ProcessSingleUser(
+	CUser ProcessSingleUser(
 		s64 selectedScoreId, // If this is not 0, then the score is looked at in isolation, triggering a notable event if it's good enough
 		CDatabaseConnection& db,
 		CUpdateBatch& newUsers,

--- a/Src/Processor/Processor.h
+++ b/Src/Processor/Processor.h
@@ -80,7 +80,7 @@ private:
 	std::chrono::steady_clock::time_point _lastBeatmapSetPollTime;
 
 	s64 _currentScoreId;
-	s64 _amountScoresProcessedSinceLastStore = 0;
+	s64 _numScoresProcessedSinceLastStore = 0;
 	void PollAndProcessNewScores();
 	void PollAndProcessNewBeatmapSets();
 

--- a/Src/Processor/Score.cpp
+++ b/Src/Processor/Score.cpp
@@ -14,12 +14,12 @@ CScore::CScore(
 	s32 beatmapId,
 	s32 score,
 	s32 maxCombo,
-	s32 amount300,
-	s32 amount100,
-	s32 amount50,
-	s32 amountMiss,
-	s32 amountGeki,
-	s32 amountKatu,
+	s32 num300,
+	s32 num100,
+	s32 num50,
+	s32 numMiss,
+	s32 numGeki,
+	s32 numKatu,
 	EMods mods
 )
 :
@@ -29,12 +29,12 @@ _userId{userId},
 _beatmapId{beatmapId},
 _score{std::max(0, score)},
 _maxCombo{std::max(0, maxCombo)},
-_amount300{std::max(0, amount300)},
-_amount100{std::max(0, amount100)},
-_amount50{std::max(0, amount50)},
-_amountMiss{std::max(0, amountMiss)},
-_amountGeki{std::max(0, amountGeki)},
-_amountKatu{std::max(0, amountKatu)},
+_num300{std::max(0, num300)},
+_num100{std::max(0, num100)},
+_num50{std::max(0, num50)},
+_numMiss{std::max(0, numMiss)},
+_numGeki{std::max(0, numGeki)},
+_numKatu{std::max(0, numKatu)},
 _mods{mods}
 {
 }

--- a/Src/Processor/Score.h
+++ b/Src/Processor/Score.h
@@ -25,12 +25,12 @@ public:
 		s32 beatmapId,
 		s32 score,
 		s32 maxCombo,
-		s32 amount300,
-		s32 amount100,
-		s32 amount50,
-		s32 amountMiss,
-		s32 amountGeki,
-		s32 amountKatu,
+		s32 num300,
+		s32 num100,
+		s32 num50,
+		s32 numMiss,
+		s32 numGeki,
+		s32 numKatu,
 		EMods mods
 	);
 	~CScore() = default;
@@ -55,13 +55,13 @@ protected:
 
 	s32 _score;
 	s32 _maxCombo;
-	s32 _amount300;
-	s32 _amount100;
-	s32 _amount50;
-	s32 _amountMiss;
+	s32 _num300;
+	s32 _num100;
+	s32 _num50;
+	s32 _numMiss;
 
-	s32 _amountGeki;
-	s32 _amountKatu;
+	s32 _numGeki;
+	s32 _numKatu;
 
 	EMods _mods;
 };

--- a/Src/Processor/Standard/StandardScore.h
+++ b/Src/Processor/Standard/StandardScore.h
@@ -13,12 +13,12 @@ public:
 		s32 beatmapId,
 		s32 score,
 		s32 maxCombo,
-		s32 amount300,
-		s32 amount100,
-		s32 amount50,
-		s32 amountMiss,
-		s32 amountGeki,
-		s32 amountKatu,
+		s32 num300,
+		s32 num100,
+		s32 num50,
+		s32 numMiss,
+		s32 numGeki,
+		s32 numKatu,
 		EMods mods,
 		const CBeatmap& beatmap
 	);

--- a/Src/Processor/Taiko/TaikoScore.cpp
+++ b/Src/Processor/Taiko/TaikoScore.cpp
@@ -10,15 +10,15 @@ CTaikoScore::CTaikoScore(
 	s32 beatmapId,
 	s32 score,
 	s32 maxCombo,
-	s32 amount300,
-	s32 amount100,
-	s32 amount50,
-	s32 amountMiss,
-	s32 amountGeki,
-	s32 amountKatu,
+	s32 num300,
+	s32 num100,
+	s32 num50,
+	s32 numMiss,
+	s32 numGeki,
+	s32 numKatu,
 	EMods mods,
 	const CBeatmap& beatmap
-) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, amount300, amount100, amount50, amountMiss, amountGeki, amountKatu, mods}
+) : CScore{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
 {
 	ComputeStrainValue(beatmap);
 	ComputeAccValue(beatmap);
@@ -67,7 +67,7 @@ void CTaikoScore::ComputeStrainValue(const CBeatmap& beatmap)
 	_strainValue *= lengthBonus;
 
 	// Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
-	_strainValue *= pow(0.985f, _amountMiss);
+	_strainValue *= pow(0.985f, _numMiss);
 
 	// Combo scaling
 	float maxCombo = beatmap.DifficultyAttribute(_mods, CBeatmap::MaxCombo);
@@ -108,16 +108,16 @@ f32 CTaikoScore::Accuracy() const
 		return 0;
 
 	return
-		clamp(static_cast<f32>(_amount100 * 150 + _amount300 * 300)
+		clamp(static_cast<f32>(_num100 * 150 + _num300 * 300)
 		/ (TotalHits() * 300), 0.0f, 1.0f);
 }
 
 s32 CTaikoScore::TotalHits() const
 {
-	return _amount50 + _amount100 + _amount300 + _amountMiss;
+	return _num50 + _num100 + _num300 + _numMiss;
 }
 
 s32 CTaikoScore::TotalSuccessfulHits() const
 {
-	return _amount50 + _amount100 + _amount300;
+	return _num50 + _num100 + _num300;
 }

--- a/Src/Processor/Taiko/TaikoScore.h
+++ b/Src/Processor/Taiko/TaikoScore.h
@@ -12,12 +12,12 @@ public:
 		s32 beatmapId,
 		s32 score,
 		s32 maxCombo,
-		s32 amount300,
-		s32 amount100,
-		s32 amount50,
-		s32 amountMiss,
-		s32 amountGeki,
-		s32 amountKatu,
+		s32 num300,
+		s32 num100,
+		s32 num50,
+		s32 numMiss,
+		s32 numGeki,
+		s32 numKatu,
 		EMods mods,
 		const CBeatmap& beatmap
 	);

--- a/Src/Processor/User.cpp
+++ b/Src/Processor/User.cpp
@@ -18,7 +18,7 @@ ForwardIt unique_own(ForwardIt first, ForwardIt last, BinaryPredicate p)
 	return ++result;
 }
 
-CUser::SPPRecord CUser::ComputePPRecord()
+void CUser::ComputePPRecord()
 {
 	// Eliminate duplicate beatmaps with lower pp
 	std::sort(std::begin(_scores), std::end(_scores), [](const CScore::SPPRecord& a, const CScore::SPPRecord& b)
@@ -60,8 +60,6 @@ CUser::SPPRecord CUser::ComputePPRecord()
 	if (_scores.size() > 0)
 		// We want the percentage, not a factor in [0, 1], hence we divide 20 by 100
 		_rating.Accuracy *= 100.0 / (20 * (1 - pow(0.95, _scores.size())));
-
-	return _rating;
 }
 
 CScore::SPPRecord CUser::XthBestScorePPRecord(unsigned int i)

--- a/Src/Processor/User.h
+++ b/Src/Processor/User.h
@@ -8,6 +8,10 @@ class CInsertionBatch;
 class CUser
 {
 public:
+	CUser(s64 id) : _id{id}
+	{
+	}
+
 	struct SPPRecord
 	{
 		f64 Value = 0;
@@ -21,6 +25,8 @@ public:
 
 	void AppendToBatch(u32 sizeThreshold, CInsertionBatch& batch);
 
+	s64 Id() const { return _id; }
+
 	size_t NumScores() const { return _scores.size(); }
 
 	void ComputePPRecord();
@@ -30,6 +36,7 @@ public:
 	CScore::SPPRecord XthBestScorePPRecord(unsigned int i);
 
 private:
+	s64 _id;
 	SPPRecord _rating;
 	std::vector<CScore::SPPRecord> _scores;
 };

--- a/Src/Processor/User.h
+++ b/Src/Processor/User.h
@@ -23,7 +23,9 @@ public:
 
 	size_t NumScores() const { return _scores.size(); }
 
-	SPPRecord ComputePPRecord();
+	void ComputePPRecord();
+
+	const SPPRecord& PPRecord() const { return _rating; }
 
 	CScore::SPPRecord XthBestScorePPRecord(unsigned int i);
 

--- a/Src/Shared/Network/DatabaseConnection.cpp
+++ b/Src/Shared/Network/DatabaseConnection.cpp
@@ -27,6 +27,9 @@ CDatabaseConnection::CDatabaseConnection(CDatabaseConnection&& other)
 
 CDatabaseConnection& CDatabaseConnection::operator=(CDatabaseConnection&& other)
 {
+	std::lock_guard<std::recursive_mutex> otherLock{other._dbMutex};
+	std::lock_guard<std::recursive_mutex> lock{_dbMutex};
+
 	_port = other._port;
 	_mySQL = other._mySQL;
 

--- a/Src/Shared/Network/QueryResult.h
+++ b/Src/Shared/Network/QueryResult.h
@@ -45,7 +45,7 @@ public:
 
 	bool NextRow();
 
-	inline s32 AmountRows() { return (s32)mysql_num_rows(_pRes); }
+	inline s32 NumRows() { return (s32)mysql_num_rows(_pRes); }
 
 	// Entire current row - array of zero terminated strings
 	inline char** CurrentRow() { return _Row; }

--- a/Src/Shared/Network/UpdateBatch.cpp
+++ b/Src/Shared/Network/UpdateBatch.cpp
@@ -18,6 +18,24 @@ CUpdateBatch::~CUpdateBatch()
 	}
 }
 
+CUpdateBatch::CUpdateBatch(CUpdateBatch&& other)
+{
+	*this = std::move(other);
+}
+
+CUpdateBatch& CUpdateBatch::operator=(CUpdateBatch&& other)
+{
+	std::lock_guard<std::mutex> otherLock{other._batchMutex};
+	std::lock_guard<std::mutex> lock{_batchMutex};
+
+	_sizeThreshold = other._sizeThreshold;
+	_empty = other._empty;
+	_pDB = std::move(other._pDB);
+	_query = std::move(other._query);
+
+	return *this;
+}
+
 void CUpdateBatch::AppendAndCommit(const std::string& values)
 {
 	std::lock_guard<std::mutex> lock{_batchMutex};

--- a/Src/Shared/Network/UpdateBatch.h
+++ b/Src/Shared/Network/UpdateBatch.h
@@ -8,6 +8,9 @@ public:
 	CUpdateBatch(std::shared_ptr<CDatabaseConnection> pDB, u32 sizeThreshold);
 	~CUpdateBatch();
 
+	CUpdateBatch& operator=(CUpdateBatch&& other);
+	CUpdateBatch(CUpdateBatch&& other);
+
 	void AppendAndCommit(const std::string& values);
 	void AppendAndCommitNonThreadsafe(const std::string& values);
 


### PR DESCRIPTION
Also adds the following minor improvements along the way:
- Thread-safe move constructors for `CDatabaseConnection` and `CUpdateBatch`
- Removes dead and now obsolete `PLAYER_TESTING` code
- Avoids various now-unnecessary DB connections
- Replaces usage of the word "amount" with "number" when referring to a countable quantity