### PR TITLE
User Metadata

### DIFF
--- a/Dependencies/StrFormat/StrFormat.h
+++ b/Dependencies/StrFormat/StrFormat.h
@@ -17,41 +17,32 @@ namespace ts_printf
 		class CStringAdaptor : CBasicAdaptor
 		{
 		public:
-
-
 			typedef std::basic_string<CharType> CString;
-
 
 			CStringAdaptor()
 			{
 			}
 
-
 			void Write(CharType Char, size_t Count)
 			{
 				m_Result.append(Count, Char);
-			} 
+			}
 
 			void Write(const CharType* szString, size_t Length)
 			{
 				m_Result.append(szString, Length);
-			} 
-
+			}
 
 			CString& GetResult()
 			{
 				return m_Result;
 			}
-			
 
 		private:
-
 			CString m_Result;
 			CStringAdaptor &operator =(const CStringAdaptor &);
 		};
 	}
-
-
 };
 
 // Render from format.
@@ -65,8 +56,6 @@ std::basic_string<typename CFormat::char_type>
 	return Adaptor.GetResult();
 }
 
-
-
 // Create format object & render for zero terminated string pointers
 template<typename CharPointer, typename... A>
 auto StrFormat(CharPointer&& CharPtr, A&& ... Args) ->
@@ -76,8 +65,6 @@ decltype(StrFormat(ts_printf::Format(std::forward<CharPointer>(CharPtr)), std::f
 {
 	return StrFormat(ts_printf::Format(std::forward<CharPointer>(CharPtr)), std::forward<A>(Args)...);
 }
-
-
 
 // Create format object & render for string references
 template<class CString, typename... A>

--- a/Dependencies/StrFormat/StringRenderer.h
+++ b/Dependencies/StrFormat/StringRenderer.h
@@ -24,10 +24,8 @@ namespace ts_printf
 				// No need to allocate any buffer, we already have the buffer right here!
 				// TODO: implement
 
-
 				CharType* pCur = Output.Allocate(Length);
 				const CharType* end = pCur + Length;
-
 
 				// Copy into buffer
 				for(; pCur != end; pCur++, pData++)
@@ -51,7 +49,7 @@ namespace ts_printf
 			static void StringDispatcher(const T(&p)[N], CharBuffer &Output)
 			{
 				// we don't need the trailing zero character
-				RenderString(Output, p, N - 1);
+				RenderString(Output, p, std::char_traits<T>::length(p));
 			}
 
 
@@ -73,14 +71,14 @@ namespace ts_printf
 				// We have a pointer to an allowed char type.
 				// (It is assumed, that it is a pointer to a zero terminated string. anyone providing a raw byte pointer for printing should specify so by using an unsigned type pointer.)
 				(std::is_pointer<typename std::remove_reference<StringType>::type>::value && is_char_type<typename std::remove_cv<typename std::remove_pointer<typename std::decay<typename std::remove_reference<StringType>::type>::type>::type>::type>::value) ||
-				
+
 				// We have an array of an allowed char type
 				(std::is_array<typename std::remove_reference<StringType>::type>::value && is_char_type<typename std::remove_cv<typename std::remove_pointer<typename std::decay<typename std::remove_reference<StringType>::type>::type>::type>::type>::value) ||
-				
+
 				// We have a non-Plain-Old-Data type. This is MOST LIKELY a basic_string<CharType>. The compiler will complain if it isn't.
 				// Other containers from the std don't have the length() method.
 				!std::is_pod<typename std::remove_reference<StringType>::type>::value
-			
+
 			>::type
 
 			irender_parameter(const FormatDesc& FormatDescription, StringType&& String, CharBuffer& Output)

--- a/Dependencies/StrFormat/printf.h
+++ b/Dependencies/StrFormat/printf.h
@@ -60,7 +60,7 @@ namespace ts_printf
 
 		template<typename CharType, template<class, class> class CParser>
 		class CFormatter
-			: 
+			:
 			protected _details::SBaseFormatter,
 			public CParser<CFormatter<CharType, CParser>, CharType>,
 			protected _details::CStringRenderer<CharType>,
@@ -85,7 +85,7 @@ namespace ts_printf
 			std::unique_ptr<SFormatDesc[]> m_FormatParts;	// contains parsed format string
 			size_t m_NumFormatParts;
 
-		
+
 
 
 
@@ -93,23 +93,23 @@ namespace ts_printf
 			{
 			}
 
-			
 
-			
+
+
 			template<u32 ParamIndex, class CAdaptor, typename A>
 			void render_parameter(const SFormatDesc& fd, CAdaptor &adaptor, CCharBuffer& buffer, A&& Arg) const
 			{
 				if(ParamIndex == fd.ParamIndex)
-				{ 
+				{
 					irender_parameter(fd, std::forward<A>(Arg), buffer);
 				}
-					
+
 				// We are at the end of the "recursion" through the argument list. Finish up by calling the common rendering method.
 				// NOTE: This isn't actual recursion, since the methods called in sequence are of DIFFERENT templates and thus not the same memory location
 				//       The compiler most likely unrolls it into a simple sequence of statements.
 				common_render_parameter(buffer, fd, adaptor);
 			}
-			
+
 			template<u32 ParamIndex, class CAdaptor, typename A, typename... B>
 			void render_parameter(const SFormatDesc& fd,CAdaptor &adaptor, CCharBuffer& buffer, A&& Arg, B&&... ArgTail) const
 			{
@@ -117,11 +117,11 @@ namespace ts_printf
 				{
 					irender_parameter(fd, std::forward<A>(Arg), buffer);
 				}
-					
+
 				render_parameter<ParamIndex+1>(fd, adaptor, buffer, std::forward<B>(ArgTail)...);
 			}
 
-			
+
 
 			template<class CAdaptor>
 			void common_render_parameter(CCharBuffer& buffer, const SFormatDesc& fd, CAdaptor& adaptor) const
@@ -180,7 +180,7 @@ namespace ts_printf
 							return;
 						}
 					}
-					else 
+					else
 					{
 						switch (fd.Alignment)
 						{
@@ -203,7 +203,7 @@ namespace ts_printf
 				adaptor.Write(result, length);
 			}
 
-			
+
 
 		public:
 
@@ -294,15 +294,11 @@ namespace ts_printf
 					}
 				}
 			}
-
 		};
-
-
 
 		// Default dispatcher is directly for string objects
 		template<template<class, class> class CParser, typename Enable = void>
 		struct FormatDispatcher;
-
 
 		// Default dispatcher is directly for string objects
 		template<template<class, class> class CParser, typename CharType>
@@ -310,11 +306,9 @@ namespace ts_printf
 		{
 			CFormatter<CharType, CParser> operator ()(std::basic_string<CharType> && FormatString) const
 			{
-
 				return CFormatter<CharType, CParser>(FormatString.c_str(), FormatString.c_str() + FormatString.length());
 			}
 		};
-
 
 		// Format dispatcher for char pointer
 		template<template<class, class> class CParser, typename CharType>
@@ -322,11 +316,9 @@ namespace ts_printf
 		{
 			CFormatter<CharType, CParser> operator ()(const CharType* r) const
 			{
-
 				return CFormatter<CharType, CParser>(r, r + std::char_traits<CharType>::length(r));
 			}
 		};
-
 
 		// Format dispatcher for char array
 		template<template<class, class> class CParser, typename CharType, size_t N>
@@ -334,8 +326,7 @@ namespace ts_printf
 		{
 			CFormatter<CharType, CParser> operator ()(const CharType(&p)[N]) const
 			{
-
-				return CFormatter<CharType, CParser>(p, p + N - 1);
+				return CFormatter<CharType, CParser>(p, p + std::char_traits<CharType>::length(p));
 			}
 		};
 	}
@@ -347,7 +338,5 @@ namespace ts_printf
 	{
 		return _details::FormatDispatcher<_details::CExtendedFormat, StringType>()(std::forward<StringType>(FormatString));
 	}
-
-
 };
 

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -223,8 +223,16 @@ void Processor::ProcessUsers(const std::vector<std::string>& userNames)
 	{
 		s64 id = xtoi64(name.c_str());
 		if (id == 0) {
-			// TODO: Allow querying IDs by name once it's available in the DB
-			continue;
+			// If the given string is not a number, try treating it as a username
+			auto res = _pDBSlave->Query(StrFormat(
+				"SELECT `user_id` FROM `{0}` WHERE `username`='{1}'",
+				_config.UserMetadataTableName, name
+			));
+
+			if (!res.NextRow())
+				continue;
+
+			id = res.S64(0);
 		}
 
 		userIds.emplace_back(id);

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -222,7 +222,8 @@ void Processor::ProcessUsers(const std::vector<std::string>& userNames)
 	for (const auto& name : userNames)
 	{
 		s64 id = xtoi64(name.c_str());
-		if (id == 0) {
+		if (id == 0)
+		{
 			// If the given string is not a number, try treating it as a username
 			auto res = _pDBSlave->Query(StrFormat(
 				"SELECT `user_id` FROM `{0}` WHERE `username`='{1}'",
@@ -273,16 +274,34 @@ void Processor::ProcessUsers(const std::vector<s64>& userIds)
 
 	Log(Success, StrFormat("Processed all {0} users.", users.size()));
 
-	Log(Info, "============================");
-	Log(Info, "======= USER SUMMARY =======");
-	Log(Info, "============================");
-	Log(Info, "      User    Perf.     Acc.");
-	Log(Info, "----------------------------");
+	Log(Info, "=============================================");
+	Log(Info, "======= USER SUMMARY ========================");
+	Log(Info, "=============================================");
+	Log(Info, "            Name        Id    Perf.      Acc.");
+	Log(Info, "---------------------------------------------");
 
 	for (const auto& user : users)
-		Log(Info, StrFormat("{0w10ar}  {1w5ar}pp  {2w6arp2}%", user.Id(), (s32)user.GetPPRecord().Value, user.GetPPRecord().Accuracy));
+	{
+		// Try to obtain name
+		std::string name = "<not-found>";
+		auto res = _pDBSlave->Query(StrFormat(
+			"SELECT `username` FROM `{0}` WHERE `user_id`='{1}'",
+			_config.UserMetadataTableName, user.Id()
+		));
 
-	Log(Info, "=============================");
+		if (res.NextRow())
+			name = res.String(0);
+
+		Log(Info, StrFormat(
+			"{0w16ar}  {1w8ar}  {2w5ar}pp  {3w6arp2} %",
+			name,
+			user.Id(),
+			(s32)user.GetPPRecord().Value,
+			user.GetPPRecord().Accuracy
+		));
+	}
+
+	Log(Info, "=============================================");
 }
 
 std::shared_ptr<DatabaseConnection> Processor::newDBConnectionMaster()

--- a/Src/Shared/configVariables.h
+++ b/Src/Shared/configVariables.h
@@ -28,6 +28,7 @@ MACRO_CONFIG_INT(ScoreUpdateInterval, 50, 1, 1000000000, "Score update interval 
 MACRO_CONFIG_INT(StallTimeThreshold, 600000, 1, 1000000000, "Time in milliseconds after which an emergency shut down is performed if no beatmap updates occured")
 
 MACRO_CONFIG_STR(UserPPColumnName, "rank_score", 100, "Column name of the user's pp value in osu_users")
+MACRO_CONFIG_STR(UserMetadataTableName, "phpbb_users", 100, "Name of the table containing user metadata such as username and restriction status")
 
 MACRO_CONFIG_STR(SlackHookDomain, "", 100, "Slack domain")
 MACRO_CONFIG_STR(SlackHookKey, "", 100, "API key for authentication")

--- a/Src/Shared/configVariables.h
+++ b/Src/Shared/configVariables.h
@@ -28,7 +28,7 @@ MACRO_CONFIG_INT(ScoreUpdateInterval, 50, 1, 1000000000, "Score update interval 
 MACRO_CONFIG_INT(StallTimeThreshold, 600000, 1, 1000000000, "Time in milliseconds after which an emergency shut down is performed if no beatmap updates occured")
 
 MACRO_CONFIG_STR(UserPPColumnName, "rank_score", 100, "Column name of the user's pp value in osu_users")
-MACRO_CONFIG_STR(UserMetadataTableName, "phpbb_users", 100, "Name of the table containing user metadata such as username and restriction status")
+MACRO_CONFIG_STR(UserMetadataTableName, "sample_users", 100, "Name of the table containing user metadata such as username and restriction status")
 
 MACRO_CONFIG_STR(SlackHookDomain, "", 100, "Slack domain")
 MACRO_CONFIG_STR(SlackHookKey, "", 100, "API key for authentication")


### PR DESCRIPTION
- Adds a config variable controlling the name of the MySQL table containing user metadata (e.g. username and restriction status)
- No longer stores pp for restricted users (matching official behavior)
- Allows passing users by-name via CLI
- Prints usernames in summary when computing pp for specific users via CLI 
- Fixes an issue with StrFormat where char arrays with known size were not treated as zero-terminated strings