### PR TITLE
Progress time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ osu!/Constants/General_Version.cs
 # Build artifacts
 /[Bb]uild
 /Bin/osu-performance*
+/Bin/*.dll
 
 # MSVC auxiliary build files
 /Win32

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ osu!.userprefs
 packages/*
 !packages/repositories.config
 .vs/*
+/.vscode

--- a/Src/Processor/CMakeLists.txt
+++ b/Src/Processor/CMakeLists.txt
@@ -78,6 +78,7 @@ set(HEADERS
 	${SHARED}/Core/Exception.h
 	${SHARED}/Core/Logger.h
 	${SHARED}/Core/SharedQueue.h
+	${SHARED}/Core/StringUtils.h
 	${SHARED}/Core/Threading.h
 	${SHARED}/Core/Types.h
 

--- a/Src/Processor/CMakeLists.txt
+++ b/Src/Processor/CMakeLists.txt
@@ -120,29 +120,31 @@ endif()
 COMMON_INCLUDE_DIRECTORIES()
 GENERATE_EXECUTABLE(osu-performance)
 
-# Copy DLLs
-if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-	add_custom_command(TARGET osu-performance POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			"${EXTERNAL}/curl/dll/64bit/libcurl.dll"
-			$<TARGET_FILE_DIR:osu-performance>
-	)
+if (WIN32)
+	# Copy DLLs
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+		add_custom_command(TARGET osu-performance POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"${EXTERNAL}/curl/dll/64bit/libcurl.dll"
+				$<TARGET_FILE_DIR:osu-performance>
+		)
 
-	add_custom_command(TARGET osu-performance POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			"${EXTERNAL}/MySQL/dll/64bit/libmariadb.dll"
-			$<TARGET_FILE_DIR:osu-performance>
-	)
-else()
-	add_custom_command(TARGET osu-performance POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			"${EXTERNAL}/curl/dll/32bit/libcurl.dll"
-			$<TARGET_FILE_DIR:osu-performance>
-	)
+		add_custom_command(TARGET osu-performance POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"${EXTERNAL}/MySQL/dll/64bit/libmariadb.dll"
+				$<TARGET_FILE_DIR:osu-performance>
+		)
+	else()
+		add_custom_command(TARGET osu-performance POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"${EXTERNAL}/curl/dll/32bit/libcurl.dll"
+				$<TARGET_FILE_DIR:osu-performance>
+		)
 
-	add_custom_command(TARGET osu-performance POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			"${EXTERNAL}/MySQL/dll/32bit/libmariadb.dll"
-			$<TARGET_FILE_DIR:osu-performance>
-	)
+		add_custom_command(TARGET osu-performance POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"${EXTERNAL}/MySQL/dll/32bit/libmariadb.dll"
+				$<TARGET_FILE_DIR:osu-performance>
+		)
+	endif()
 endif()

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -191,8 +191,7 @@ void Processor::ProcessAllUsers(bool reProcess, u32 numThreads)
 		begin += userIdStep;
 		numUsersProcessed += res.NumRows();
 
-		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
-		LogProgress(numUsersProcessed, numUsers, elapsed);
+		LogProgress(numUsersProcessed, numUsers, std::chrono::steady_clock::now() - startTime);
 
 		u32 numPendingQueries = 0;
 
@@ -265,8 +264,7 @@ void Processor::ProcessUsers(const std::vector<s64>& userIds)
 			userId
 		));
 
-		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
-		LogProgress(users.size(), userIds.size(), elapsed);
+		LogProgress(users.size(), userIds.size(), std::chrono::steady_clock::now() - startTime);
 	}
 
 	Log(Info, StrFormat("Sorting {0} users.", users.size()));
@@ -351,8 +349,7 @@ void Processor::queryAllBeatmapDifficulties()
 	{
 		queryBeatmapDifficulty(begin, std::min(begin + step, maxBeatmapId+1));
 
-		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
-		LogProgress(_beatmaps.size(), numBeatmaps, elapsed);
+		LogProgress(_beatmaps.size(), numBeatmaps, std::chrono::steady_clock::now() - startTime);
 
 		// This prevents stall checks to kill us during difficulty load
 		_lastBeatmapSetPollTime = steady_clock::now();

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -215,7 +215,11 @@ void Processor::ProcessAllUsers(bool reProcess, u32 numThreads)
 		storeCount(*_pDB, lastUserIdKey(), begin);
 	}
 
-	Log(Success, StrFormat("Processed all {0} users.", numUsers));
+	Log(Success, StrFormat(
+		"Processed all {0} users for {1}.",
+		numUsers,
+		durationToString(std::chrono::steady_clock::now() - startTime)
+	));
 }
 
 void Processor::ProcessUsers(const std::vector<std::string>& userNames)
@@ -276,7 +280,11 @@ void Processor::ProcessUsers(const std::vector<s64>& userIds)
 		return a.Id() > b.Id();
 	});
 
-	Log(Success, StrFormat("Processed all {0} users.", users.size()));
+	Log(Success, StrFormat(
+		"Processed {0} users for {1}.",
+		users.size(),
+		durationToString(std::chrono::steady_clock::now() - startTime)
+	));
 
 	Log(Info, "=============================================");
 	Log(Info, "======= USER SUMMARY ========================");
@@ -355,7 +363,11 @@ void Processor::queryAllBeatmapDifficulties()
 		_lastBeatmapSetPollTime = steady_clock::now();
 	}
 
-	Log(Success, StrFormat("Loaded difficulties for a total of {0} beatmaps.", _beatmaps.size()));
+	Log(Success, StrFormat(
+		"Loaded difficulties for a total of {0} beatmaps for {1}.",
+		_beatmaps.size(),
+		durationToString(std::chrono::steady_clock::now() - startTime)
+	));
 }
 
 bool Processor::queryBeatmapDifficulty(s32 startId, s32 endId)

--- a/Src/Processor/Processor.cpp
+++ b/Src/Processor/Processor.cpp
@@ -135,6 +135,8 @@ void Processor::ProcessAllUsers(bool reProcess, u32 numThreads)
 
 	Log(Info, StrFormat("Processing all users starting with ID {0}.", begin));
 
+	auto startTime = std::chrono::steady_clock::now();
+
 	auto res = _pDBSlave->Query(StrFormat(
 		"SELECT MAX(`user_id`),COUNT(`user_id`) FROM `osu_user_stats{0}` WHERE `user_id`>={1}",
 		GamemodeSuffix(_gamemode), begin
@@ -189,7 +191,8 @@ void Processor::ProcessAllUsers(bool reProcess, u32 numThreads)
 		begin += userIdStep;
 		numUsersProcessed += res.NumRows();
 
-		LogProgress(numUsersProcessed, numUsers);
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
+		LogProgress(numUsersProcessed, numUsers, elapsed);
 
 		u32 numPendingQueries = 0;
 
@@ -249,6 +252,8 @@ void Processor::ProcessUsers(const std::vector<s64>& userIds)
 
 	Log(Info, StrFormat("Processing {0} users.", userIds.size()));
 
+	auto startTime = std::chrono::steady_clock::now();
+
 	std::vector<User> users;
 	for (s64 userId : userIds)
 	{
@@ -260,7 +265,8 @@ void Processor::ProcessUsers(const std::vector<s64>& userIds)
 			userId
 		));
 
-		LogProgress(users.size(), userIds.size());
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
+		LogProgress(users.size(), userIds.size(), elapsed);
 	}
 
 	Log(Info, StrFormat("Sorting {0} users.", users.size()));
@@ -332,6 +338,8 @@ void Processor::queryAllBeatmapDifficulties()
 
 	Log(Info, "Retrieving all beatmap difficulties.");
 
+	auto startTime = std::chrono::steady_clock::now();
+
 	auto res = _pDBSlave->Query("SELECT MAX(`beatmap_id`),COUNT(DISTINCT `beatmap_id`) FROM `osu_beatmap_difficulty_attribs` WHERE 1");
 
 	if (!res.NextRow())
@@ -343,7 +351,8 @@ void Processor::queryAllBeatmapDifficulties()
 	{
 		queryBeatmapDifficulty(begin, std::min(begin + step, maxBeatmapId+1));
 
-		LogProgress(_beatmaps.size(), numBeatmaps);
+		auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime);
+		LogProgress(_beatmaps.size(), numBeatmaps, elapsed);
 
 		// This prevents stall checks to kill us during difficulty load
 		_lastBeatmapSetPollTime = steady_clock::now();

--- a/Src/Shared/Core/Logger.cpp
+++ b/Src/Shared/Core/Logger.cpp
@@ -38,13 +38,15 @@ void Logger::Log(ELogType flags, const string& text)
 
 void Logger::LogProgress(u64 current, u64 total, chrono::milliseconds elapsedMs)
 {
-	string timeStr = toString(elapsedMs);
+	f64 fraction = (f64)current / total;
+
+	auto projectedMs = elapsedMs * (1 / fraction);
+	string timeStr = StrFormat("{0}/{1}", toString(elapsedMs), toString(projectedMs));
 
 	string totalStr = StrFormat("{0}", total);
-	string unitsFmt = string{"{0w"} + to_string(totalStr.size() * 2 + 12) + "}";
+	string unitsFmt = string{"{0w"} + to_string(totalStr.size() * 2 + 8) + "}";
 
-	f64 fraction = (f64)current / total;
-	string units = StrFormat("{2w6arp2} % ({0}/{1})", current, total, fraction * 100);
+	string units = StrFormat("{2w3ar}% ({0}/{1}) ", current, total, (s32)std::round(fraction * 100), timeStr);
 	// Give units some space in case they're short enough
 	units = StrFormat(unitsFmt, units);
 

--- a/Src/Shared/Core/Logger.cpp
+++ b/Src/Shared/Core/Logger.cpp
@@ -10,16 +10,6 @@
 
 using namespace std;
 
-void Log(ELogType flags, const string& text)
-{
-	Logger::Instance()->Log(flags, move(text));
-}
-
-void LogProgress(u64 current, u64 total, chrono::milliseconds elapsedMs)
-{
-	Logger::Instance()->LogProgress(current, total, elapsedMs);
-}
-
 Logger::~Logger()
 {
 	Log(None, CONSOLE_RESET CONSOLE_SHOW_CURSOR);
@@ -34,38 +24,6 @@ unique_ptr<Logger>& Logger::Instance()
 void Logger::Log(ELogType flags, const string& text)
 {
 	_pActive->Send([this, flags, text]() { logText(flags, text); });
-}
-
-void Logger::LogProgress(u64 current, u64 total, chrono::milliseconds elapsedMs)
-{
-	f64 fraction = (f64)current / total;
-
-	auto projectedMs = elapsedMs * (1 / fraction);
-	string timeStr = StrFormat("{0}/{1}", toString(elapsedMs), toString(projectedMs));
-
-	string totalStr = StrFormat("{0}", total);
-	string unitsFmt = string{"{0w"} + to_string(totalStr.size() * 2 + 8) + "}";
-
-	string units = StrFormat("{2w3ar}% ({0}/{1}) ", current, total, (s32)std::round(fraction * 100), timeStr);
-	// Give units some space in case they're short enough
-	units = StrFormat(unitsFmt, units);
-
-	s32 usableWidth = max(0, consoleWidth() - 4 - (s32)units.size() - (s32)timeStr.size() - CONSOLE_PREFIX_LEN);
-
-	s32 numFilledChars = (s32)round(usableWidth * fraction);
-
-	string body(usableWidth, ' ');
-	if (numFilledChars > 0) {
-		for (s32 i = 0; i < numFilledChars; ++i)
-			body[i] = '=';
-		if (numFilledChars < usableWidth) {
-			body[numFilledChars] = '>';
-		}
-	}
-
-	string message = StrFormat("[{0}] {1} {2}", body, units, timeStr);
-
-	Log(Progress, message);
 }
 
 Logger::Logger()

--- a/Src/Shared/Core/Logger.cpp
+++ b/Src/Shared/Core/Logger.cpp
@@ -56,10 +56,10 @@ void Logger::LogProgress(u64 current, u64 total, chrono::milliseconds elapsedMs)
 
 	string body(usableWidth, ' ');
 	if (numFilledChars > 0) {
-		for (s32 i = 0; i < numFilledChars - 1; ++i)
+		for (s32 i = 0; i < numFilledChars; ++i)
 			body[i] = '=';
-		if (numFilledChars < (s32)body.size()) {
-			body[numFilledChars - 1] = '>';
+		if (numFilledChars < usableWidth) {
+			body[numFilledChars] = '>';
 		}
 	}
 

--- a/Src/Shared/Core/Logger.h
+++ b/Src/Shared/Core/Logger.h
@@ -89,13 +89,16 @@ private:
 		auto m = duration_cast<minutes>(dur -= h);
 		auto s = duration_cast<seconds>(dur -= m);
 
-		std::string result = StrFormat("{0}s", s.count());
+		std::string result = StrFormat("{0w2arf0}s", s.count());
 		if (m.count() > 0)
-			result = StrFormat("{0}m", m.count()) + result;
+			result = StrFormat("{0w2arf0}m", m.count()) + result;
 		if (h.count() > 0)
-			result = StrFormat("{0}h", h.count()) + result;
+			result = StrFormat("{0w2arf0}h", h.count()) + result;
 		if (d.count() > 0)
 			result = StrFormat("{0}d", d.count()) + result;
+
+		if (result[0] == '0')
+			result.erase(result.begin());
 
 		return result;
 	}

--- a/Src/Shared/Core/Logger.h
+++ b/Src/Shared/Core/Logger.h
@@ -63,7 +63,7 @@ public:
 
 	void Log(ELogType flags, const std::string& text);
 
-	void LogProgress(u64 current, u64 total);
+	void LogProgress(u64 current, u64 total, std::chrono::milliseconds elapsedMs);
 
 	enum class EStream : byte
 	{
@@ -78,6 +78,28 @@ private:
 
 	static s32 consoleWidth();
 
+	template <typename T>
+	static std::string toString(T dur)
+	{
+		using namespace std::chrono;
+		using day_t = duration<long long, std::ratio<3600 * 24>>;
+
+		auto d = duration_cast<day_t>(dur);
+		auto h = duration_cast<hours>(dur -= d);
+		auto m = duration_cast<minutes>(dur -= h);
+		auto s = duration_cast<seconds>(dur -= m);
+
+		std::string result = StrFormat("{0}s", s.count());
+		if (m.count() > 0)
+			result = StrFormat("{0}m", m.count()) + result;
+		if (h.count() > 0)
+			result = StrFormat("{0}h", h.count()) + result;
+		if (d.count() > 0)
+			result = StrFormat("{0}d", d.count()) + result;
+
+		return result;
+	}
+
 	bool enableControlCharacters();
 
 	void logText(ELogType flags, const std::string& text);
@@ -90,4 +112,4 @@ private:
 };
 
 void Log(ELogType flags, const std::string& text);
-void LogProgress(u64 current, u64 total);
+void LogProgress(u64 current, u64 total, std::chrono::milliseconds elapsedMs);

--- a/Src/Shared/Core/Logger.h
+++ b/Src/Shared/Core/Logger.h
@@ -84,8 +84,8 @@ public:
 		// Time display. Looks like so:
 		//     3s/17m03s
 		auto projectedDuration = duration * (1 / fraction);
-		auto projectedDurationStr = toString(projectedDuration);
-		string timeStr = StrFormat("{0}/{1}", toString(duration), projectedDurationStr);
+		auto projectedDurationStr = durationToString(projectedDuration);
+		string timeStr = StrFormat("{0}/{1}", durationToString(duration), projectedDurationStr);
 		string timeFmt = string{"{2w"} + to_string(projectedDurationStr.size() * 2 + 1) + "ar}";
 
 		// Put the label together. Looks like so:
@@ -132,31 +132,6 @@ private:
 	static std::unique_ptr<Logger> createLogger();
 
 	static s32 consoleWidth();
-
-	template <typename T>
-	static std::string toString(T dur)
-	{
-		using namespace std::chrono;
-		using day_t = duration<long long, std::ratio<3600 * 24>>;
-
-		auto d = duration_cast<day_t>(dur);
-		auto h = duration_cast<hours>(dur -= d);
-		auto m = duration_cast<minutes>(dur -= h);
-		auto s = duration_cast<seconds>(dur -= m);
-
-		std::string result = StrFormat("{0w2arf0}s", s.count());
-		if (m.count() > 0)
-			result = StrFormat("{0w2arf0}m", m.count()) + result;
-		if (h.count() > 0)
-			result = StrFormat("{0w2arf0}h", h.count()) + result;
-		if (d.count() > 0)
-			result = StrFormat("{0}d", d.count()) + result;
-
-		if (result[0] == '0')
-			result.erase(result.begin());
-
-		return result;
-	}
 
 	bool enableControlCharacters();
 

--- a/Src/Shared/Core/StringUtils.h
+++ b/Src/Shared/Core/StringUtils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+
+template <typename T>
+static std::string durationToString(T dur)
+{
+	using namespace std::chrono;
+	using day_t = duration<long long, std::ratio<3600 * 24>>;
+
+	auto d = duration_cast<day_t>(dur);
+	auto h = duration_cast<hours>(dur -= d);
+	auto m = duration_cast<minutes>(dur -= h);
+	auto s = duration_cast<seconds>(dur -= m);
+
+	std::string result = StrFormat("{0w2arf0}s", s.count());
+	if (m.count() > 0)
+		result = StrFormat("{0w2arf0}m", m.count()) + result;
+	if (h.count() > 0)
+		result = StrFormat("{0w2arf0}h", h.count()) + result;
+	if (d.count() > 0)
+		result = StrFormat("{0}d", d.count()) + result;
+
+	if (result[0] == '0')
+		result.erase(result.begin());
+
+	return result;
+}

--- a/Src/Shared/Shared.h
+++ b/Src/Shared/Shared.h
@@ -121,6 +121,7 @@ typedef unsigned int uint;
 #include <StrFormat.h>
 
 #include "Core/Exception.h"
+#include "Core/StringUtils.h"
 
 #include "Math/Math.h"
 


### PR DESCRIPTION
- Adds printing of current job duration and estimated total duration to progress bars.
- Fixes some bugs with progress bars
- Stops copying DLLs on non-windows compiles (non-critical, but less annoying)
- gitignores DLL files in the Bin directory while we're at it
- Outputs final duration of long-running operations once they finish
- Slightly improves formatting of progress bar labels