### PR TITLE
Adjusting Hidden Mod As Speed Multiplier

### DIFF
--- a/Src/Processor/Standard/StandardScore.cpp
+++ b/Src/Processor/Standard/StandardScore.cpp
@@ -124,7 +124,7 @@ void StandardScore::computeAimValue(const Beatmap& beatmap)
 	_aimValue *= approachRateFactor;
 
 	if ((_mods & EMods::Hidden) > 0)
-		_aimValue *= 1.18f;
+		_aimValue *= 1.03f;
 
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
@@ -154,6 +154,9 @@ void StandardScore::computeSpeedValue(const Beatmap& beatmap)
 	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
 	if (maxCombo > 0)
 		_speedValue *= std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	
+	if ((_mods & EMods::Hidden) > 0)
+		_speedValue *= 1.18f;
 
 	// Scale the speed value with accuracy _slightly_
 	_speedValue *= 0.5f + Accuracy() / 2.0f;


### PR DESCRIPTION
As mentioned in my bug fix, this puts the change suggested live.

What this does is adjusts `_speedValue` to have a `1.18*` multiplier for the HD mod and nerfs `_aimValue` from `1.18` to `1.03` for HD. Personally I would like to adjust other things but for the sake of this being concise and clean I'll leave it like this for now. I was going to adjust the multiplier for FL but I believe that the multiplier is actually quite large as is so I am hesitant to adjust it haphazardly. 

For now this is fine I believe. I'm excited to see how this shakes up the meta! 



Note: Reading through this code really makes me want to clean up areas I think could be improved though :o