### PR TITLE
AR Fix for Aim on HD

### DIFF
--- a/Src/Processor/Standard/StandardScore.cpp
+++ b/Src/Processor/Standard/StandardScore.cpp
@@ -125,7 +125,7 @@ void StandardScore::computeAimValue(const Beatmap& beatmap)
 
 	// We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
 	if ((_mods & EMods::Hidden) > 0)
-		_aimValue *= (1.02f+(11.0f - approachRate)/50f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
+		_aimValue *= (1.02f+(11.0f - approachRate)/50.0f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
 
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.

--- a/Src/Processor/Standard/StandardScore.cpp
+++ b/Src/Processor/Standard/StandardScore.cpp
@@ -125,7 +125,7 @@ void StandardScore::computeAimValue(const Beatmap& beatmap)
 
 	// We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
 	if ((_mods & EMods::Hidden) > 0)
-		_aimValue *= (1.02f+(11.0f - approachRate)/50.0f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
+		_aimValue *= (1.02f + (11.0f - approachRate) / 50.0f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
 
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.

--- a/Src/Processor/Standard/StandardScore.cpp
+++ b/Src/Processor/Standard/StandardScore.cpp
@@ -125,7 +125,7 @@ void StandardScore::computeAimValue(const Beatmap& beatmap)
 
 	// We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
 	if ((_mods & EMods::Hidden) > 0)
-		_aimValue *= (1.2f+(11.0f - approachRate)/50f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
+		_aimValue *= (1.02f+(11.0f - approachRate)/50f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
 
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.

--- a/Src/Processor/Standard/StandardScore.cpp
+++ b/Src/Processor/Standard/StandardScore.cpp
@@ -123,8 +123,9 @@ void StandardScore::computeAimValue(const Beatmap& beatmap)
 
 	_aimValue *= approachRateFactor;
 
+	// We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
 	if ((_mods & EMods::Hidden) > 0)
-		_aimValue *= 1.03f;
+		_aimValue *= (1.2f+(11.0f - approachRate)/50f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
 
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.


### PR DESCRIPTION
This is a solution to the problem posed by https://github.com/ppy/osu-performance/issues/45.

I believe this to be much superior to the system currently implemented. This makes it so the maps that are problems still get nerfed (and in some cases, even harder) but there is better balance towards lower ended HD maps. Since there are people who are much better at running the actual calculations to see how this may better balance things, I will leave it up to them.