### PR TITLE
 When selecting a specific score, still update all others if their pp values differ

### DIFF
--- a/Src/Processor/Score.h
+++ b/Src/Processor/Score.h
@@ -34,6 +34,7 @@ public:
 		EMods mods
 	);
 
+	s64 Id() const { return _scoreId; }
 	s64 UserId() const { return _userId; }
 	s32 BeatmapId() const { return _beatmapId; }
 

--- a/Src/Processor/Score.h
+++ b/Src/Processor/Score.h
@@ -33,7 +33,6 @@ public:
 		s32 numKatu,
 		EMods mods
 	);
-	~Score() = default;
 
 	s64 UserId() const { return _userId; }
 	s32 BeatmapId() const { return _beatmapId; }


### PR DESCRIPTION
This prevents a user's pp from not corresponding to the pp of their scores after recomputing due to new scores after algorithm changes.