### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ After compilation, an executable named `osu-performance` is placed in the _Bin_ 
 
 where command controls which scores are the target of the computation.
 The following commands are valid:
-* `new`: Continually poll for new scores and compute pp of these
 * `all`: Compute pp of all users
+* `new`: Continually poll for new scores and compute pp of these
+* `scores`: Compute pp of specific scores
 * `users`: Compute pp of specific users
 
 The gamemode to compute pp for can be selected via the `-m` option, which may take the value `osu`, `taiko`, `catch`, or `mania`.

--- a/include/pp/Common.h
+++ b/include/pp/Common.h
@@ -44,6 +44,7 @@ protected:
 
 // std::string operations
 std::vector<std::string> Split(std::string text, const std::string& delim);
+std::string Join(const std::vector<std::string>& words, const std::string& delim);
 std::string ToLower(std::string str);
 std::string ToUpper(std::string str);
 
@@ -93,6 +94,13 @@ enum EMods : u32
 	FreeModAllowed = NoFail | Easy | Hidden | HardRock | SuddenDeath | Flashlight | FadeIn | Relax | Relax2 | SpunOut | keyMod,
 	ScoreIncreaseMods = Hidden | HardRock | DoubleTime | Flashlight | FadeIn
 };
+
+inline EMods MaskRelevantDifficultyMods(EMods mods)
+{
+	return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | keyMod));
+}
+
+std::string ToString(EMods mods);
 
 enum class EGamemode
 {

--- a/include/pp/performance/Beatmap.h
+++ b/include/pp/performance/Beatmap.h
@@ -59,15 +59,6 @@ public:
 	}
 
 private:
-	static const EMods s_relevantDifficultyMods = static_cast<EMods>(
-		DoubleTime | HalfTime | HardRock | Easy | keyMod
-	);
-
-	static EMods maskRelevantDifficultyMods(EMods mods)
-	{
-		return static_cast<EMods>(mods & s_relevantDifficultyMods);
-	}
-
 	static const std::unordered_map<std::string, EDifficultyAttributeType> s_difficultyAttributes;
 
 	// General information

--- a/include/pp/performance/Processor.h
+++ b/include/pp/performance/Processor.h
@@ -28,6 +28,7 @@ public:
 	void ProcessAllUsers(bool reProcess, u32 numThreads);
 	void ProcessUsers(const std::vector<std::string>& userNames);
 	void ProcessUsers(const std::vector<s64>& userIds);
+	void ProcessScores(const std::vector<s64>& scoreIds);
 
 private:
 	static const Beatmap::ERankedStatus s_minRankedStatus;

--- a/include/pp/performance/Processor.h
+++ b/include/pp/performance/Processor.h
@@ -133,6 +133,9 @@ private:
 	void storeCount(DatabaseConnection& db, std::string key, s64 value);
 	s64 retrieveCount(DatabaseConnection& db, std::string key);
 
+	std::string retrieveUserName(s64 userId, DatabaseConnection& db) const;
+	std::string retrieveBeatmapName(s32 beatmapId, DatabaseConnection& db) const;
+
 	EGamemode _gamemode;
 
 	RWMutex _beatmapMutex;

--- a/include/pp/performance/User.h
+++ b/include/pp/performance/User.h
@@ -29,6 +29,8 @@ public:
 
 	size_t NumScores() const { return _scores.size(); }
 
+	const std::vector<Score::PPRecord>& Scores() const { return _scores; }
+
 	void ComputePPRecord();
 
 	const PPRecord& GetPPRecord() const { return _rating; }

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -5,7 +5,8 @@
 
 PP_NAMESPACE_BEGIN
 
-std::vector<std::string> Split(std::string text, const std::string& delim) {
+std::vector<std::string> Split(std::string text, const std::string& delim)
+{
     std::vector<std::string> result;
     while (true) {
         size_t begin = text.find_last_of(delim);
@@ -21,14 +22,86 @@ std::vector<std::string> Split(std::string text, const std::string& delim) {
     return result;
 }
 
-std::string ToLower(std::string str) {
+std::string Join(const std::vector<std::string>& words, const std::string& delim)
+{
+	std::string result;
+	for (size_t i = 0; i < words.size(); ++i)
+	{
+		result += words[i];
+		if (i < words.size() - 1)
+			result += delim;
+	}
+	return result;
+}
+
+std::string ToLower(std::string str)
+{
     transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)tolower(c); });
     return str;
 }
 
-std::string ToUpper(std::string str) {
+std::string ToUpper(std::string str)
+{
     transform(begin(str), end(str), begin(str), [](unsigned char c) { return (char)toupper(c); });
     return str;
+}
+
+std::string ToString(EMods mods)
+{
+	std::string result = "";
+
+	std::vector<std::string> modStrings;
+
+	// Keymods
+	if (mods & Key1)
+		modStrings.emplace_back("K1");
+	if (mods & Key2)
+		modStrings.emplace_back("K2");
+	if (mods & Key3)
+		modStrings.emplace_back("K3");
+	if (mods & Key4)
+		modStrings.emplace_back("K4");
+	if (mods & Key5)
+		modStrings.emplace_back("K5");
+	if (mods & Key6)
+		modStrings.emplace_back("K6");
+	if (mods & Key7)
+		modStrings.emplace_back("K7");
+	if (mods & Key8)
+		modStrings.emplace_back("K8");
+	if (mods & Key9)
+		modStrings.emplace_back("K9");
+	if (mods & Key10)
+		modStrings.emplace_back("K10");
+
+	// Cheap out
+	if (mods & NoFail)
+		modStrings.emplace_back("NF");
+	if (mods & SpunOut)
+		modStrings.emplace_back("SO");
+
+	// Visiblity
+	if (mods & Hidden)
+		modStrings.emplace_back("HD");
+	if (mods & Flashlight)
+		modStrings.emplace_back("FL");
+
+	// Speed
+	if (mods & DoubleTime)
+		modStrings.emplace_back("DT");
+	if (mods & HalfTime)
+		modStrings.emplace_back("HT");
+
+	// Difficulty
+	if (mods & HardRock)
+		modStrings.emplace_back("HR");
+	if (mods & Easy)
+		modStrings.emplace_back("EZ");
+
+	if (modStrings.empty())
+		return "None";
+
+	return Join(modStrings, ",");
 }
 
 std::string GamemodeSuffix(EGamemode gamemode)

--- a/src/performance/Beatmap.cpp
+++ b/src/performance/Beatmap.cpp
@@ -21,13 +21,13 @@ Beatmap::Beatmap(s32 id)
 
 f32 Beatmap::DifficultyAttribute(EMods mods, EDifficultyAttributeType type) const
 {
-	auto difficultyIt = _difficulty.find(maskRelevantDifficultyMods(mods));
+	auto difficultyIt = _difficulty.find(MaskRelevantDifficultyMods(mods));
 	return difficultyIt == std::end(_difficulty) ? 0.0f : difficultyIt->second[type];
 }
 
 void Beatmap::SetDifficultyAttribute(EMods mods, EDifficultyAttributeType type, f32 value)
 {
-	_difficulty[maskRelevantDifficultyMods(mods)][type] = value;
+	_difficulty[MaskRelevantDifficultyMods(mods)][type] = value;
 }
 
 PP_NAMESPACE_END

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -815,7 +815,7 @@ User Processor::processSingleUserGeneric(
 			if (ratingChange < s_notableEventRatingDifferenceMinimum)
 				continue;
 
-			tlog::info() << StrFormat("Notable event: /b/{0} /u/{1}", score.BeatmapId(), userId);
+			tlog::info() << StrFormat("Notable event: s{0} u{1} b{2}", score.Id(), userId, score.BeatmapId());
 
 			db.NonQueryBackground(StrFormat(
 				"INSERT INTO "

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -500,14 +500,17 @@ bool Processor::queryBeatmapDifficulty(DatabaseConnection& dbSlave, s32 startId,
 void Processor::pollAndProcessNewScores()
 {
 	static const s64 s_lastScoreIdUpdateStep = 100;
+	static const s64 s_maxNumScores = 1000;
 
 	UpdateBatch newUsers{_pDB, 0};  // We want the updates to occur immediately
 	UpdateBatch newScores{_pDB, 0}; // batches are used to conform the interface of processSingleUser
 
 	// Obtain all new scores since the last poll and process them
 	auto res = _pDBSlave->Query(StrFormat(
-		"SELECT `score_id`,`user_id`,`pp` FROM `osu_scores{0}_high` WHERE `score_id` > {1} ORDER BY `score_id` ASC",
-		GamemodeSuffix(_gamemode), _currentScoreId
+		"SELECT `score_id`,`user_id`,`pp` "
+		"FROM `osu_scores{0}_high` "
+		"WHERE `score_id` > {1} ORDER BY `score_id` ASC LIMIT {3}",
+		GamemodeSuffix(_gamemode), _currentScoreId, _config.UserMetadataTableName, s_maxNumScores
 	));
 
 	// Only reset the poll timer when we find nothing. Otherwise we want to directly keep going

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -304,8 +304,8 @@ void Processor::ProcessScores(const std::vector<s64>& scoreIds)
 	auto progress = tlog::progress(scoreIds.size());
 
 	struct Result {
-		Score::PPRecord Score;
-		User User;
+		Score::PPRecord PP;
+		s64 UserId;
 		EMods Mods;
 	};
 
@@ -335,17 +335,17 @@ void Processor::ProcessScores(const std::vector<s64>& scoreIds)
 			continue;
 		}
 
-		results.push_back({*scoreIt, user, res[1]});
+		results.push_back({*scoreIt, user.Id(), res[1]});
 		progress.update(results.size());
 	}
 
 	tlog::info() << StrFormat("Sorting {0} results.", results.size());
 
 	std::sort(std::begin(results), std::end(results), [](const Result& a, const Result& b) {
-		if (a.Score.Value != b.Score.Value)
-			return a.Score.Value > b.Score.Value;
+		if (a.PP.Value != b.PP.Value)
+			return a.PP.Value > b.PP.Value;
 
-		return a.Score.ScoreId > b.Score.ScoreId;
+		return a.PP.ScoreId > b.PP.ScoreId;
 	});
 
 	tlog::success() << StrFormat(
@@ -364,10 +364,10 @@ void Processor::ProcessScores(const std::vector<s64>& scoreIds)
 	{
 		tlog::info() << StrFormat(
 			"{0w16ar}  {1p1w6ar}pp  {2w6arp2} %  {3} - {4}",
-			retrieveUserName(result.User.Id(), *_pDBSlave),
-			result.Score.Value,
-			result.Score.Accuracy * 100,
-			retrieveBeatmapName(result.Score.BeatmapId, *_pDBSlave),
+			retrieveUserName(result.UserId, *_pDBSlave),
+			result.PP.Value,
+			result.PP.Accuracy * 100,
+			retrieveBeatmapName(result.PP.BeatmapId, *_pDBSlave),
 			ToString(result.Mods)
 		);
 	}

--- a/src/performance/main.cpp
+++ b/src/performance/main.cpp
@@ -97,9 +97,22 @@ int main(s32 argc, char* argv[])
 
 			parser.Parse();
 
-			std::vector<std::string> userNames = args::get(usersPositional);
 			Processor processor{ToGamemode(args::get(modePositional)), args::get(configFlag)};
 			processor.ProcessUsers(args::get(usersPositional));
+		});
+
+		args::Command scoresCommand(commands, "scores", "Compute pp of specific scores", [&](args::Subparser& parser)
+		{
+			args::PositionalList<s64> scoresPositional{
+				parser,
+				"scores",
+				"Score IDs to recompute pp for.",
+			};
+
+			parser.Parse();
+
+			Processor processor{ToGamemode(args::get(modePositional)), args::get(configFlag)};
+			processor.ProcessScores(args::get(scoresPositional));
 		});
 
 		args::GlobalOptions argumentsGlobal{parser, argumentsGroup};


### PR DESCRIPTION
- More detailed console output when processing new scores as they happen
- Ensures new score queries are broken down into digestable chunks (relevant if score processing hasn't been going on for a longer while)
- Better technique for iterating through _all_ users when recomputing. Mostly improves performance for sparsely populated user IDs
- Add command for recomputing pp of specific scores