### PR TITLE
Adjusting high-AR for Speed and Aim

### DIFF
--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 3.4f;
+		approachRateFactor += (approachRate - 10.33f) / 3.33f;
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 4.0f;
+		approachRateFactor += (approachRate - 10.33f) / 3.6f;
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += 0.45f * (approachRate - 10.33f);
+		approachRateFactor += (approachRate - 10.33f) / 4.0f;
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!
@@ -153,7 +153,14 @@ void OsuScore::computeSpeedValue(const Beatmap& beatmap)
 	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
 	if (maxCombo > 0)
 		_speedValue *= std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	
+	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
+	f32 approachRateFactor = 1.0f;
+	if (approachRate > 10.33f)
+		approachRateFactor += (approachRate - 10.33f) / 3.0f;
 
+	_speedValue *= approachRateFactor;
+	
 	if ((_mods & EMods::Hidden) > 0)
 		_speedValue *= 1.18f;
 

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 3.2f;
+		approachRateFactor += 0.35 * (approachRate - 10.33f);
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!
@@ -128,9 +128,6 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
 		_aimValue *= 1.45f * LengthBonus;
-		// Bonus for HDFL
-		// if ((_mods & EMods::Hidden) > 0)
-		// 	_aimValue *= 1.05f;
 
 	// Scale the aim value with accuracy _slightly_
 	_aimValue *= 0.5f + Accuracy() / 2.0f;
@@ -160,7 +157,7 @@ void OsuScore::computeSpeedValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 3.0f;
+		approachRateFactor += 0.30f * (approachRate - 10.33f);
 
 	_speedValue *= approachRateFactor;
 	

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -129,8 +129,8 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
 		_aimValue *= 1.45f * LengthBonus;
 		// Bonus for HDFL
-		if ((_mods & EMods::Hidden) > 0)
-			_aimValue *= 1.05f;
+		// if ((_mods & EMods::Hidden) > 0)
+		// 	_aimValue *= 1.05f;
 
 	// Scale the aim value with accuracy _slightly_
 	_aimValue *= 0.5f + Accuracy() / 2.0f;

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -128,6 +128,8 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
 		_aimValue *= 1.45f * LengthBonus;
+		if ((_mods & EMods::Hidden) > 0)
+			_aimValue *= 1.05f;
 
 	// Scale the aim value with accuracy _slightly_
 	_aimValue *= 0.5f + Accuracy() / 2.0f;

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -157,7 +157,7 @@ void OsuScore::computeSpeedValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += 0.30f * (approachRate - 10.33f);
+		approachRateFactor += 0.25f * (approachRate - 10.33f);
 
 	_speedValue *= approachRateFactor;
 	

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -128,6 +128,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	if ((_mods & EMods::Flashlight) > 0)
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
 		_aimValue *= 1.45f * LengthBonus;
+		// Bonus for HDFL
 		if ((_mods & EMods::Hidden) > 0)
 			_aimValue *= 1.05f;
 

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 3.6f;
+		approachRateFactor += (approachRate - 10.33f) / 3.4f;
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -109,7 +109,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 1.0f;
 	if (approachRate > 10.33f)
-		approachRateFactor += (approachRate - 10.33f) / 3.33f;
+		approachRateFactor += (approachRate - 10.33f) / 3.2f;
 	else if (approachRate < 8.0f)
 	{
 		// HD is worth more with lower ar!


### PR DESCRIPTION
This is a partial solution to the AR issue I previously addressed, issue #46

Note, need to see how this would affect leaderboards (it probably won't change that much), but I actually suck at coding so if someone could please recalculate the top100 or top1000, that'd be a huge help.

Currently, high-AR (and low-AR) only affects the aim component of pp. This is essentially saying that high-AR does not affect streaming (or AR in general). Put this into a thought experiment, where you take popular stream maps and convert them to AR11. From my experience, and from the trends of AR11 plays, streaming with AR11 is harder (subjective) and is underrated/not preferred (objective). The best example of a high AR streaming playstyle is [Matrix](https://osu.ppy.sh/u/5052899). Some of his +(HD),HR,DT scores on stream heavy maps are extremely impressive (subjective) and you barely see any other players replicating his plays, while on popular AR11 maps (e.g. Bombs Away, Shiori, etc.), there have been plenty of FCs.

Possible changes to this (just some ideas), aim could be nerfed less, while speed ar bonus is decreased, this way it serves mainly as a buff to speed, rather than a rebalance (though I feel like doing this might cause extra buffing to every high AR play, and won't make high AR streaming as appealing).

Basically, this adjustment/rebalance moves part of the high AR bonus from aim to speed. Aim is still affected by high AR, but (subjective) it's affected less than speed.

And here's a spreadsheet with filsdelama with the speed bonus and high-AR applied: https://docs.google.com/spreadsheets/d/1nxRwsL0CJ4SX_zr0Ec-eN6YjIH51EKn6JUaVPyNKZvA/edit#gid=40620073

Simply said, this high-AR rebalance will not affect most people. (HD)DT scores on the higher end are slightly affected because they go above AR10.33, but changes are minimal/unnoticeable. This mainly affects (HD),HR,DT scores like filsdelama's plays and rarer plays like some of Matrix's HR,DT scores.

New rankings with adjustment: http://sakisan.be/osu/pr59.html
As I predicted, most players experience little change, from a quick skim, it looks like a few (like 10-20) players lose over 100 ranks, and barely anyone gains any significant ranks (except Matrix), which basically shows why I said streaming AR11 was underrated/not preferred.

(from old dump, 05/17/18)
Hastebin of filsdelama's top40 scores: https://hastebin.com/ocavuzojeq
Hastebin of Matrix's scores: https://hastebin.com/jozohiragu

Edit - New Spreadsheet showing some scores/players with pr59 (osu-performance) and pr2798 (osu) [high-AR and high-CS]: https://docs.google.com/spreadsheets/d/1fP8Fg2Rc8BELtoccAepu0TieJd26Tl1om0fRC_oFA-g/edit?usp=sharing