### PR TITLE
Implement xexxar/mbmasher’s length bonus summation

### DIFF
--- a/include/pp/performance/Beatmap.h
+++ b/include/pp/performance/Beatmap.h
@@ -23,6 +23,7 @@ public:
 		Strain,
 		HitWindow300,
 		ScoreMultiplier,
+		LengthBonus,
 
 		NumTypes,
 	};

--- a/include/pp/performance/Beatmap.h
+++ b/include/pp/performance/Beatmap.h
@@ -23,8 +23,8 @@ public:
 		Strain,
 		HitWindow300,
 		ScoreMultiplier,
-		LengthBonus,
-
+		AimLengthBonus,
+		SpeedLengthBonus,
 		NumTypes,
 	};
 

--- a/src/performance/Beatmap.cpp
+++ b/src/performance/Beatmap.cpp
@@ -12,7 +12,8 @@ const std::unordered_map<std::string, Beatmap::EDifficultyAttributeType> Beatmap
 	{"Strain",           Strain},
 	{"Hit window 300",   HitWindow300},
 	{"Score multiplier", ScoreMultiplier},
-	{"Length Bonus", LengthBonus},
+	{"Aim Length Bonus", AimLengthBonus},
+	{"Speed Length Bonus", SpeedLengthBonus},
 };
 
 Beatmap::Beatmap(s32 id)

--- a/src/performance/Beatmap.cpp
+++ b/src/performance/Beatmap.cpp
@@ -12,6 +12,7 @@ const std::unordered_map<std::string, Beatmap::EDifficultyAttributeType> Beatmap
 	{"Strain",           Strain},
 	{"Hit window 300",   HitWindow300},
 	{"Score multiplier", ScoreMultiplier},
+	{"Length Bonus", LengthBonus},
 };
 
 Beatmap::Beatmap(s32 id)

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -93,8 +93,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	int numTotalHits = TotalHits();
 
 	// Longer maps are worth more
-	f32 LengthBonus = 0.95f + 0.4f * std::min(1.0f, static_cast<f32>(numTotalHits) / 2000.0f) +
-		(numTotalHits > 2000 ? log10(static_cast<f32>(numTotalHits) / 2000.0f) * 0.5f : 0.0f);
+	f32 LengthBonus = beatmap.DifficultyAttribute(_mods, Beatmap::LengthBonus);
 
 	_aimValue *= LengthBonus;
 

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -125,8 +125,13 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 		_aimValue *= (1.02f + (11.0f - approachRate) / 50.0f); // Gives a 1.04 bonus for AR10, a 1.06 bonus for AR9, a 1.02 bonus for AR11.
 
 	if ((_mods & EMods::Flashlight) > 0)
+	{
+		f32 flashlightLengthBonus = 0.95f + 0.4f * std::min(1.0f, static_cast<f32>(numTotalHits) / 2000.0f) +
+									(numTotalHits > 2000 ? log10(static_cast<f32>(numTotalHits) / 2000.0f) * 0.5f : 0.0f);
+
 		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
-		_aimValue *= 1.45f * LengthBonus;
+		_aimValue *= 1.45f * flashlightLengthBonus;
+	}
 
 	// Scale the aim value with accuracy _slightly_
 	_aimValue *= 0.5f + Accuracy() / 2.0f;

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -93,7 +93,7 @@ void OsuScore::computeAimValue(const Beatmap& beatmap)
 	int numTotalHits = TotalHits();
 
 	// Longer maps are worth more
-	f32 LengthBonus = beatmap.DifficultyAttribute(_mods, Beatmap::LengthBonus);
+	f32 LengthBonus = beatmap.DifficultyAttribute(_mods, Beatmap::AimLengthBonus);
 
 	_aimValue *= LengthBonus;
 
@@ -141,7 +141,7 @@ void OsuScore::computeSpeedValue(const Beatmap& beatmap)
 	int numTotalHits = TotalHits();
 
 	// Longer maps are worth more
-	_speedValue *= beatmap.DifficultyAttribute(_mods, Beatmap::LengthBonus);
+	_speedValue *= beatmap.DifficultyAttribute(_mods, Beatmap::SpeedLengthBonus);
 
 	// Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
 	_speedValue *= pow(0.97f, _numMiss);

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -141,9 +141,7 @@ void OsuScore::computeSpeedValue(const Beatmap& beatmap)
 	int numTotalHits = TotalHits();
 
 	// Longer maps are worth more
-	_speedValue *=
-		0.95f + 0.4f * std::min(1.0f, static_cast<f32>(numTotalHits) / 2000.0f) +
-		(numTotalHits > 2000 ? log10(static_cast<f32>(numTotalHits) / 2000.0f) * 0.5f : 0.0f);
+	_speedValue *= beatmap.DifficultyAttribute(_mods, Beatmap::LengthBonus);
 
 	// Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
 	_speedValue *= pow(0.97f, _numMiss);


### PR DESCRIPTION
Don’t merge. PRing for visibility in-case people want to follow along.

Implements the ppcalc changes relevant for https://github.com/ppy/osu-performance/issues/64.