### PR TITLE
Fix AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ install:
   - git submodule update --init --recursive
 build_script:
   - cd C:\osu-performance
-  - cmake -G "Visual Studio 15 2017 Win64"
+  - cmake -G "Visual Studio 15 2017 Win64" .
   - set MSBuildLogger="C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   - set MSBuildOptions=/v:m /p:Configuration=Release /logger:%MSBuildLogger%
   - msbuild %MSBuildOptions% osu-performance.sln

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -46,11 +46,11 @@ Processor::Processor(EGamemode gamemode, const std::string& configFile)
 				if (retrieveCount(*_pDB, "docker_db_step") >= 2)
 					break;
 			}
-			catch (const DatabaseException& dbe)
+			catch (const DatabaseException&)
 			{
 				// Will occur if the database fails to connect (container not initialised)
 			}
-			catch (const ProcessorException& pe)
+			catch (const ProcessorException&)
 			{
 				// Will occur if the retrieval of the docker step fails (tables not initialised)
 			}


### PR DESCRIPTION
Latest CMake no longer implicitly uses the current directory. It must be supplied explicitly.

Also fixing warnings due to unused local variables along the way.