### PR TITLE
Always join thread on dctor

### DIFF
--- a/src/shared/Active.cpp
+++ b/src/shared/Active.cpp
@@ -6,11 +6,10 @@ PP_NAMESPACE_BEGIN
 Active::~Active()
 {
 	if (!_isDone)
-	{
 		send(std::bind(&Active::doDone, this), false);
-		if (_thread.joinable())
-			_thread.join();
-	}
+
+	if (_thread.joinable())
+		_thread.join();
 }
 
 void Active::Send(std::function<void()> callback)


### PR DESCRIPTION
Was getting the following:

```
terminate called without an active exception
Aborted (core dumped)
```

Found this post (https://stackoverflow.com/a/21978054) on the issue.