### PR TITLE
Write docker db step after processor exits

### DIFF
--- a/include/pp/performance/Processor.h
+++ b/include/pp/performance/Processor.h
@@ -141,6 +141,7 @@ private:
 	std::string retrieveBeatmapName(s32 beatmapId, DatabaseConnection& db) const;
 
 	EGamemode _gamemode;
+	bool _isDocker = false;
 
 	RWMutex _beatmapMutex;
 	bool _shallShutdown = false;

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -28,12 +28,12 @@ Processor::Processor(EGamemode gamemode, const std::string& configFile)
 
 	readConfig(configFile);
 
+	_isDocker = std::getenv("DOCKER") != NULL;
+
 	_pDataDog = std::make_unique<DDog>(_config.DataDogHost, _config.DataDogPort);
 	_pDataDog->Increment("osu.pp.startups", 1, {StrFormat("mode:{0}", GamemodeTag(_gamemode))});
 
-	bool isDocker = std::getenv("DOCKER") != NULL;
-
-	if (isDocker)
+	if (_isDocker)
 	{
 		tlog::info() << "Waiting for database...";
 
@@ -66,13 +66,13 @@ Processor::Processor(EGamemode gamemode, const std::string& configFile)
 	queryBeatmapBlacklist();
 	queryBeatmapDifficultyAttributes();
 	queryAllBeatmapDifficulties(16);
-
-	if (isDocker)
-		storeCount(*_pDB, "docker_db_step", 3);
 }
 
 Processor::~Processor()
 {
+	if (_isDocker)
+		storeCount(*_pDB, "docker_db_step", 3);
+
 	tlog::info() << "Shutting down.";
 }
 


### PR DESCRIPTION
Just a minor convenience improvement - if docker_db_step is written too early then the es-indexer (the next step) indexes out-of-date scores.