### PR TITLE
[osu!std] Change NF multiplier to be based on amount of misses

### DIFF
--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -68,7 +68,7 @@ void OsuScore::computeTotalValue(const Beatmap& beatmap)
 	f32 multiplier = 1.12f; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things
 
 	if ((_mods & EMods::NoFail) > 0)
-		multiplier *= 0.90f;
+		multiplier *= std::max(0.9f, 1.0f - 0.02f * _numMiss);
 
 	int numTotalHits = TotalHits();
 	if ((_mods & EMods::SpunOut) > 0)


### PR DESCRIPTION
While NF definitely shouldn't punish FC plays removing negative multiplier will make HP system pretty much obsolete so i propose making negative multiplier scale with amount of misses for low amount of misses:
![image](https://user-images.githubusercontent.com/8269193/101712252-28e4d680-3aa6-11eb-9793-06bafcb01c56.png)
https://www.desmos.com/calculator/sojrkmgsrw

Amount of misses when multiplier becomes the same as live was chosen arbitrary so its up for debate