### PR TITLE
[osu!std] Approximate amount of sliderbreaks in a play

### DIFF
--- a/include/pp/performance/osu/OsuScore.h
+++ b/include/pp/performance/osu/OsuScore.h
@@ -35,6 +35,7 @@ private:
 	f32 _aimValue;
 	f32 _speedValue;
 	f32 _accValue;
+	s32 _effectiveMissCount;
 
 	void computeTotalValue(const Beatmap& beatmap);
 	f32 _totalValue;


### PR DESCRIPTION
This is a port of sliderbreak approximation that's being used in delta_t's pp rework. It guesses amount of sliderbreaks based on achieved combo.
This change lacks delta's smooth miss curve (I'm flooring miss amount here) due to fact that its not being used in any calculation that requires anything more than an integer

![image](https://user-images.githubusercontent.com/8269193/102568803-4ee92700-40f5-11eb-8306-d373e7670b5c.png)
Example miss-per-achieved-combo graph for a beatmap with 1000 max combo and 200 sliders