### PR TITLE
Log exceptions immediately

### DIFF
--- a/include/pp/Common.h
+++ b/include/pp/Common.h
@@ -35,10 +35,13 @@ protected:
 	std::string _description;
 };
 
-#define DEFINE_EXCEPTION(x) \
-	class x : public Exception \
-	{ public: x(const std::string& file, s32 line, const std::string& description) \
-	: Exception{file, line, description} {} }
+#define DEFINE_EXCEPTION(x)                                                  \
+	class x : public Exception                                               \
+	{                                                                        \
+	public:                                                                  \
+		x(const std::string &file, s32 line, const std::string &description) \
+			: Exception{file, line, description} { Log(); }                  \
+	}
 
 #define SRC_POS __FILE__,__LINE__
 


### PR DESCRIPTION
Currently when the pp calculator throws an exception, it dies with a non-descript message:
![image](https://user-images.githubusercontent.com/1329837/125790405-b3ae6106-3efc-493b-8869-2d6145b0d136.png)

This makes it something like the following:
![image](https://user-images.githubusercontent.com/1329837/125790598-8515af98-f3e9-4717-be73-9626bc84e5c9.png)
Where the exception is at least visible in that last line before the errors.

This isn't really the proper way to do this. I suspect that the entire program's execution was supposed to be wrapped inside an exception handler, but this doesn't seem to be working (/shrug):
https://github.com/ppy/osu-performance/blob/f7d7ca236bb2015f3e22304913a19ae719b13c8a/src/performance/main.cpp#L182-L191