### PR TITLE
Fix flashlight being scoped to in non-osu rulesets

### DIFF
--- a/include/pp/Common.h
+++ b/include/pp/Common.h
@@ -113,6 +113,7 @@ inline EMods MaskRelevantDifficultyMods(EGamemode mode, EMods mods)
 	case EGamemode::Osu:
 		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | Flashlight));
 
+	case EGamemode::Taiko:
 	case EGamemode::Catch:
 		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy));
 		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy));

--- a/include/pp/Common.h
+++ b/include/pp/Common.h
@@ -118,7 +118,7 @@ inline EMods MaskRelevantDifficultyMods(EGamemode mode, EMods mods)
 		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy));
 
 	case EGamemode::Mania:
-		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | Flashlight | keyMod));
+		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | keyMod));
 
 	default:
 		throw std::runtime_error("Invalid mode provided."); // Should never occur

--- a/include/pp/Common.h
+++ b/include/pp/Common.h
@@ -98,13 +98,6 @@ enum EMods : u32
 	ScoreIncreaseMods = Hidden | HardRock | DoubleTime | Flashlight | FadeIn
 };
 
-inline EMods MaskRelevantDifficultyMods(EMods mods)
-{
-	return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | Flashlight | keyMod));
-}
-
-std::string ToString(EMods mods);
-
 enum class EGamemode
 {
 	Osu,
@@ -112,6 +105,27 @@ enum class EGamemode
 	Catch,
 	Mania,
 };
+
+inline EMods MaskRelevantDifficultyMods(EGamemode mode, EMods mods)
+{
+	switch (mode)
+	{
+	case EGamemode::Osu:
+		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | Flashlight));
+
+	case EGamemode::Catch:
+		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy));
+		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy));
+
+	case EGamemode::Mania:
+		return static_cast<EMods>(mods & (DoubleTime | HalfTime | HardRock | Easy | Flashlight | keyMod));
+
+	default:
+		throw std::runtime_error("Invalid mode provided."); // Should never occur
+	}
+}
+
+std::string ToString(EMods mods);
 
 std::string GamemodeSuffix(EGamemode gamemode);
 std::string GamemodeName(EGamemode gamemode);

--- a/include/pp/performance/Beatmap.h
+++ b/include/pp/performance/Beatmap.h
@@ -57,6 +57,7 @@ public:
 	void SetNumSliders(s32 numSliders) { _numSliders = numSliders; }
 	void SetNumSpinners(s32 numSpinners) { _numSpinners = numSpinners; }
 	void SetDifficultyAttribute(EMods mods, EDifficultyAttributeType type, f32 value);
+	void SetMode(EGamemode mode) { _mode = mode; }
 
 	static EDifficultyAttributeType DifficultyAttributeFromName(const std::string &difficultyAttributeName)
 	{

--- a/src/performance/Beatmap.cpp
+++ b/src/performance/Beatmap.cpp
@@ -22,13 +22,13 @@ Beatmap::Beatmap(s32 id)
 
 f32 Beatmap::DifficultyAttribute(EMods mods, EDifficultyAttributeType type) const
 {
-	auto difficultyIt = _difficulty.find(MaskRelevantDifficultyMods(mods));
+	auto difficultyIt = _difficulty.find(MaskRelevantDifficultyMods(_mode, mods));
 	return difficultyIt == std::end(_difficulty) ? 0.0f : difficultyIt->second[type];
 }
 
 void Beatmap::SetDifficultyAttribute(EMods mods, EDifficultyAttributeType type, f32 value)
 {
-	_difficulty[MaskRelevantDifficultyMods(mods)][type] = value;
+	_difficulty[MaskRelevantDifficultyMods(_mode, mods)][type] = value;
 }
 
 PP_NAMESPACE_END

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -654,6 +654,7 @@ bool Processor::queryBeatmapDifficulty(DatabaseConnection& dbSlave, s32 startId,
 		beatmap.SetNumSliders(res.IsNull(8) ? 0 : (s32)res[8]);
 		beatmap.SetNumSpinners(res.IsNull(7) ? 0 : (s32)res[7]);
 		beatmap.SetDifficultyAttribute(res[2], _difficultyAttributes[(s32)res[3]], res[4]);
+		beatmap.SetMode(_gamemode);
 	}
 
 	if (endId != 0) {


### PR DESCRIPTION
The new flashlight attribute/mod combination is only present for the osu! ruleset.

Without this change, other rulesets like osu!catch would scope to the `+FL` combination, which doesn't exist, and return zeroed difficulty attribute values.

Testing:
- osu!catch: No longer exhibits any edge cases. E.g. http://osu.ppy.sh/scores/fruits/200536911 would calculate to 0pp without these changes.
- osu!: Compared vs current master to verify there's no differences.