### PR TITLE
Skip unsupported attributes

### DIFF
--- a/include/pp/performance/Beatmap.h
+++ b/include/pp/performance/Beatmap.h
@@ -59,6 +59,11 @@ public:
 	void SetDifficultyAttribute(EMods mods, EDifficultyAttributeType type, f32 value);
 	void SetMode(EGamemode mode) { _mode = mode; }
 
+	static bool ContainsAttribute(const std::string &difficultyAttributeName)
+	{
+		return s_difficultyAttributes.find(difficultyAttributeName) != s_difficultyAttributes.end();
+	}
+
 	static EDifficultyAttributeType DifficultyAttributeFromName(const std::string &difficultyAttributeName)
 	{
 		return s_difficultyAttributes.at(difficultyAttributeName);

--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -825,6 +825,13 @@ void Processor::queryBeatmapDifficultyAttributes()
 	while (res.NextRow())
 	{
 		u32 id = res[0];
+
+		if (!Beatmap::ContainsAttribute(res[1]))
+		{
+			tlog::warning() << StrFormat("Unsupported attribute '{0}', skipping.", res[1]);
+			continue;
+		}
+
 		if (_difficultyAttributes.size() < id + 1)
 			_difficultyAttributes.resize(id + 1);
 


### PR DESCRIPTION
Haven't tested yet. Would need to be merged back into the previous (released) pp calculator in order for it to not crash on newly-added attributes.