### PR TITLE
Prevent attributes being set out-of-bounds

### DIFF
--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -653,7 +653,11 @@ bool Processor::queryBeatmapDifficulty(DatabaseConnection& dbSlave, s32 startId,
 		beatmap.SetNumHitCircles(res.IsNull(1) ? 0 : (s32)res[1]);
 		beatmap.SetNumSliders(res.IsNull(8) ? 0 : (s32)res[8]);
 		beatmap.SetNumSpinners(res.IsNull(7) ? 0 : (s32)res[7]);
-		beatmap.SetDifficultyAttribute(res[2], _difficultyAttributes[(s32)res[3]], res[4]);
+
+		s32 attribId = (s32)res[3];
+		if (attribId < _difficultyAttributes.size())
+			beatmap.SetDifficultyAttribute(res[2], _difficultyAttributes[attribId], res[4]);
+
 		beatmap.SetMode(_gamemode);
 	}
 


### PR DESCRIPTION
This looks to work on testing locally, it was writing out of bounds in the array (because the attrib id can't be mapped locally so the array isn't resized to accommodate it) so potentially replacing other values in memory. Also means that it could also segfault.