### PR TITLE
Apply refactorings to match osu!-side changes

### DIFF
--- a/include/pp/performance/mania/ManiaScore.h
+++ b/include/pp/performance/mania/ManiaScore.h
@@ -22,8 +22,7 @@ public:
 		s32 numGeki,
 		s32 numKatu,
 		EMods mods,
-		const Beatmap& beatmap
-	);
+		const Beatmap &beatmap);
 
 	f32 TotalValue() const override;
 	f32 Accuracy() const override;
@@ -34,11 +33,11 @@ private:
 	void computeTotalValue();
 	f32 _totalValue;
 
-	void computeStrainValue(const Beatmap& beatmap);
-	void computeAccValue(const Beatmap& beatmap);
+	void computeDifficultyValue(const Beatmap &beatmap);
+	void computeAccuracyValue(const Beatmap &beatmap);
 
-	f32 _strainValue;
-	f32 _accValue;
+	f32 _difficultyValue;
+	f32 _accuracyValue;
 };
 
 PP_NAMESPACE_END

--- a/include/pp/performance/osu/OsuScore.h
+++ b/include/pp/performance/osu/OsuScore.h
@@ -32,7 +32,7 @@ public:
 private:
 	f32 _aimValue;
 	f32 _speedValue;
-	f32 _accValue;
+	f32 _accuracyValue;
 	f32 _flashlightValue;
 	s32 _effectiveMissCount;
 
@@ -42,8 +42,10 @@ private:
 	void computeEffectiveMissCount(const Beatmap &beatmap);
 	void computeAimValue(const Beatmap &beatmap);
 	void computeSpeedValue(const Beatmap &beatmap);
-	void computeAccValue(const Beatmap &beatmap);
+	void computeAccuracyValue(const Beatmap &beatmap);
 	void computeFlashlightValue(const Beatmap &beatmap);
+
+	f32 getComboScalingFactor(const Beatmap &beatmap);
 };
 
 PP_NAMESPACE_END

--- a/include/pp/performance/taiko/TaikoScore.h
+++ b/include/pp/performance/taiko/TaikoScore.h
@@ -22,8 +22,7 @@ public:
 		s32 numGeki,
 		s32 numKatu,
 		EMods mods,
-		const Beatmap& beatmap
-	);
+		const Beatmap &beatmap);
 
 	f32 TotalValue() const override;
 	f32 Accuracy() const override;
@@ -34,11 +33,11 @@ private:
 	void computeTotalValue();
 	f32 _totalValue;
 
-	void computeStrainValue(const Beatmap& beatmap);
-	void computeAccValue(const Beatmap& beatmap);
+	void computeDifficultyValue(const Beatmap &beatmap);
+	void computeAccuracyValue(const Beatmap &beatmap);
 
-	f32 _strainValue;
-	f32 _accValue;
+	f32 _difficultyValue;
+	f32 _accuracyValue;
 };
 
 PP_NAMESPACE_END

--- a/src/performance/catch/CatchScore.cpp
+++ b/src/performance/catch/CatchScore.cpp
@@ -17,8 +17,7 @@ CatchScore::CatchScore(
 	s32 numGeki,
 	s32 numKatu,
 	EMods mods,
-	const Beatmap& beatmap
-) : Score{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
+	const Beatmap &beatmap) : Score{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
 {
 	// Don't count scores made with supposedly unranked mods
 	if ((_mods & EMods::Relax) > 0 ||
@@ -35,15 +34,11 @@ CatchScore::CatchScore(
 	// Longer maps are worth more. "Longer" means how many hits there are which can contribute to combo
 	int numTotalHits = totalComboHits();
 
-	// Longer maps are worth more
 	f32 lengthBonus =
 		0.95f + 0.3f * std::min<f32>(1.0f, static_cast<f32>(numTotalHits) / 2500.0f) +
 		(numTotalHits > 2500 ? log10(static_cast<f32>(numTotalHits) / 2500.0f) * 0.475f : 0.0f);
-
-	// Longer maps are worth more
 	_value *= lengthBonus;
 
-	// Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
 	_value *= pow(0.97f, _numMiss);
 
 	// Combo scaling
@@ -72,13 +67,10 @@ CatchScore::CatchScore(
 	}
 
 	if ((_mods & EMods::Flashlight) > 0)
-		// Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
 		_value *= 1.35f * lengthBonus;
 
-	// Scale the aim value with accuracy _slightly_
 	_value *= pow(Accuracy(), 5.5f);
 
-	// Custom multipliers for NoFail and SpunOut.
 	if ((_mods & EMods::NoFail) > 0)
 		_value *= 0.90f;
 

--- a/src/performance/mania/ManiaScore.cpp
+++ b/src/performance/mania/ManiaScore.cpp
@@ -17,11 +17,10 @@ ManiaScore::ManiaScore(
 	s32 numGeki,
 	s32 numKatu,
 	EMods mods,
-	const Beatmap& beatmap
-) : Score{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
+	const Beatmap &beatmap) : Score{scoreId, mode, userId, beatmapId, score, maxCombo, num300, num100, num50, numMiss, numGeki, numKatu, mods}
 {
-	computeStrainValue(beatmap);
-	computeAccValue(beatmap);
+	computeDifficultyValue(beatmap);
+	computeAccuracyValue(beatmap);
 
 	computeTotalValue();
 }
@@ -43,8 +42,8 @@ void ManiaScore::computeTotalValue()
 	}
 
 	/*
-	    Arbitrary initial value for scaling pp in order to standardize distributions across game modes.
-	    The specific number has no intrinsic meaning and can be adjusted as needed.
+		Arbitrary initial value for scaling pp in order to standardize distributions across game modes.
+		The specific number has no intrinsic meaning and can be adjusted as needed.
 	*/
 	f32 multiplier = 0.8f;
 
@@ -58,62 +57,56 @@ void ManiaScore::computeTotalValue()
 		multiplier *= 0.50f;
 
 	_totalValue =
-			std::pow(
-			std::pow(_strainValue, 1.1f) +
-			std::pow(_accValue, 1.1f), 1.0f / 1.1f
-		) * multiplier;
+		std::pow(
+			std::pow(_difficultyValue, 1.1f) +
+				std::pow(_accuracyValue, 1.1f),
+			1.0f / 1.1f) *
+		multiplier;
 }
 
-void ManiaScore::computeStrainValue(const Beatmap& beatmap)
+void ManiaScore::computeDifficultyValue(const Beatmap &beatmap)
 {
 	// Scale score up, so it's comparable to other keymods
 	f32 scoreMultiplier = beatmap.DifficultyAttribute(_mods, Beatmap::ScoreMultiplier);
 
 	if (scoreMultiplier <= 0)
 	{
-		_strainValue = 0;
+		_difficultyValue = 0;
 		return;
 	}
 
 	_score *= static_cast<s32>(1.0f / scoreMultiplier); // We don't really mind rounding errors with such small magnitude.
 
-	// Obtain strain difficulty
-	_strainValue = pow(5.0f * std::max(1.0f, beatmap.DifficultyAttribute(_mods, Beatmap::Strain) / 0.2f) - 4.0f, 2.2f) / 135.0f;
+	_difficultyValue = pow(5.0f * std::max(1.0f, beatmap.DifficultyAttribute(_mods, Beatmap::Strain) / 0.2f) - 4.0f, 2.2f) / 135.0f;
 
-	// Longer maps are worth more
-	_strainValue *= 1 + 0.1f * std::min(1.0f, static_cast<f32>(TotalHits()) / 1500.0f);
+	_difficultyValue *= 1 + 0.1f * std::min(1.0f, static_cast<f32>(TotalHits()) / 1500.0f);
 
-	// Counter mashing through maps
 	if (_score <= 500000)
-		_strainValue = 0;
+		_difficultyValue = 0;
 	else if (_score <= 600000)
-		_strainValue *= static_cast<f32>(_score - 500000) / 100000.0f * 0.3f;
+		_difficultyValue *= static_cast<f32>(_score - 500000) / 100000.0f * 0.3f;
 	else if (_score <= 700000)
-		_strainValue *= 0.3f + static_cast<f32>(_score - 600000) / 100000.0f * 0.25f;
+		_difficultyValue *= 0.3f + static_cast<f32>(_score - 600000) / 100000.0f * 0.25f;
 	else if (_score <= 800000)
-		_strainValue *= 0.55f + static_cast<f32>(_score - 700000) / 100000.0f * 0.20f;
+		_difficultyValue *= 0.55f + static_cast<f32>(_score - 700000) / 100000.0f * 0.20f;
 	else if (_score <= 900000)
-		_strainValue *= 0.75f + static_cast<f32>(_score - 800000) / 100000.0f * 0.15f;
+		_difficultyValue *= 0.75f + static_cast<f32>(_score - 800000) / 100000.0f * 0.15f;
 	else
-		_strainValue *= 0.90f + static_cast<f32>(_score - 900000) / 100000.0f * 0.1f;
+		_difficultyValue *= 0.90f + static_cast<f32>(_score - 900000) / 100000.0f * 0.1f;
 }
 
-void ManiaScore::computeAccValue(const Beatmap& beatmap)
+void ManiaScore::computeAccuracyValue(const Beatmap &beatmap)
 {
 	f32 hitWindow300 = beatmap.DifficultyAttribute(_mods, Beatmap::HitWindow300);
 	if (hitWindow300 <= 0)
 	{
-		_accValue = 0;
+		_accuracyValue = 0;
 		return;
 	}
 
 	// Lots of arbitrary values from testing.
 	// Considering to use derivation from perfect accuracy in a probabilistic manner - assume normal distribution
-	_accValue = std::max(0.0f, 0.2f - ((hitWindow300 - 34) * 0.006667f)) * _strainValue
-		* pow((std::max(0.0f, static_cast<f32>(_score - 960000)) / 40000.0f), 1.1f);
-
-	// Bonus for many hitcircles - it's harder to keep good accuracy up for longer
-	//_accValue *= std::min<f32>(1.15f, pow(static_cast<f32>(TotalHits()) / 1500.0f, 0.3f));
+	_accuracyValue = std::max(0.0f, 0.2f - ((hitWindow300 - 34) * 0.006667f)) * _difficultyValue * pow((std::max(0.0f, static_cast<f32>(_score - 960000)) / 40000.0f), 1.1f);
 }
 
 f32 ManiaScore::Accuracy() const
@@ -121,9 +114,7 @@ f32 ManiaScore::Accuracy() const
 	if (TotalHits() == 0)
 		return 0;
 
-	return
-		Clamp(static_cast<f32>(_num50 * 50 + _num100 * 100 + _numKatu * 200 + (_num300 + _numGeki) * 300)
-		/ (TotalHits() * 300), 0.0f, 1.0f);
+	return Clamp(static_cast<f32>(_num50 * 50 + _num100 * 100 + _numKatu * 200 + (_num300 + _numGeki) * 300) / (TotalHits() * 300), 0.0f, 1.0f);
 }
 
 s32 ManiaScore::TotalHits() const

--- a/src/performance/osu/OsuScore.cpp
+++ b/src/performance/osu/OsuScore.cpp
@@ -23,7 +23,7 @@ OsuScore::OsuScore(
 
 	computeAimValue(beatmap);
 	computeSpeedValue(beatmap);
-	computeAccValue(beatmap);
+	computeAccuracyValue(beatmap);
 	computeFlashlightValue(beatmap);
 
 	computeTotalValue(beatmap);
@@ -82,7 +82,6 @@ void OsuScore::computeTotalValue(const Beatmap &beatmap)
 		return;
 	}
 
-	// Custom multipliers for NoFail and SpunOut.
 	f32 multiplier = 1.12f; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
 	if ((_mods & EMods::NoFail) > 0)
@@ -96,7 +95,7 @@ void OsuScore::computeTotalValue(const Beatmap &beatmap)
 		std::pow(
 			std::pow(_aimValue, 1.1f) +
 				std::pow(_speedValue, 1.1f) +
-				std::pow(_accValue, 1.1f) +
+				std::pow(_accuracyValue, 1.1f) +
 				std::pow(_flashlightValue, 1.1),
 			1.0f / 1.1f) *
 		multiplier;
@@ -113,20 +112,15 @@ void OsuScore::computeAimValue(const Beatmap &beatmap)
 
 	int numTotalHits = TotalHits();
 
-	// Longer maps are worth more.
 	f32 lengthBonus = 0.95f + 0.4f * std::min(1.0f, static_cast<f32>(numTotalHits) / 2000.0f) +
 					  (numTotalHits > 2000 ? log10(static_cast<f32>(numTotalHits) / 2000.0f) * 0.5f : 0.0f);
-
 	_aimValue *= lengthBonus;
 
 	// Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
 	if (_effectiveMissCount > 0)
 		_aimValue *= 0.97f * std::pow(1.0f - std::pow(_effectiveMissCount / static_cast<f32>(numTotalHits), 0.775f), _effectiveMissCount);
 
-	// Combo scaling.
-	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
-	if (maxCombo > 0)
-		_aimValue *= std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	_aimValue *= getComboScalingFactor(beatmap);
 
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 0.0f;
@@ -146,6 +140,7 @@ void OsuScore::computeAimValue(const Beatmap &beatmap)
 
 	if (beatmap.NumSliders() > 0)
 	{
+		float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
 		f32 estimateSliderEndsDropped = std::min(std::max(std::min(static_cast<f32>(_num100 + _num50 + _numMiss), maxCombo - _maxCombo), 0.0f), estimateDifficultSliders);
 		f32 sliderFactor = beatmap.DifficultyAttribute(_mods, Beatmap::SliderFactor);
 		f32 sliderNerfFactor = (1.0f - sliderFactor) * std::pow(1.0f - estimateSliderEndsDropped / estimateDifficultSliders, 3) + sliderFactor;
@@ -153,7 +148,7 @@ void OsuScore::computeAimValue(const Beatmap &beatmap)
 	}
 
 	_aimValue *= Accuracy();
-	// It is important to also consider accuracy difficulty when doing that.
+	// It is important to consider accuracy difficulty when scaling with accuracy.
 	_aimValue *= 0.98f + (pow(beatmap.DifficultyAttribute(_mods, Beatmap::OD), 2) / 2500);
 }
 
@@ -163,7 +158,6 @@ void OsuScore::computeSpeedValue(const Beatmap &beatmap)
 
 	int numTotalHits = TotalHits();
 
-	// Longer maps are worth more.
 	f32 lengthBonus = 0.95f + 0.4f * std::min(1.0f, static_cast<f32>(numTotalHits) / 2000.0f) +
 					  (numTotalHits > 2000 ? log10(static_cast<f32>(numTotalHits) / 2000.0f) * 0.5f : 0.0f);
 	_speedValue *= lengthBonus;
@@ -172,10 +166,7 @@ void OsuScore::computeSpeedValue(const Beatmap &beatmap)
 	if (_effectiveMissCount > 0)
 		_speedValue *= 0.97f * std::pow(1.0f - std::pow(_effectiveMissCount / static_cast<f32>(numTotalHits), 0.775f), std::pow(static_cast<f32>(_effectiveMissCount), 0.875f));
 
-	// Combo scaling.
-	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
-	if (maxCombo > 0)
-		_speedValue *= std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	_speedValue *= getComboScalingFactor(beatmap);
 
 	f32 approachRate = beatmap.DifficultyAttribute(_mods, Beatmap::AR);
 	f32 approachRateFactor = 0.0f;
@@ -194,7 +185,7 @@ void OsuScore::computeSpeedValue(const Beatmap &beatmap)
 	_speedValue *= std::pow(0.98f, _num50 < numTotalHits / 500.0f ? 0.0f : _num50 - numTotalHits / 500.0f);
 }
 
-void OsuScore::computeAccValue(const Beatmap &beatmap)
+void OsuScore::computeAccuracyValue(const Beatmap &beatmap)
 {
 	// This percentage only considers HitCircles of any value - in this part of the calculation we focus on hitting the timing hit window.
 	f32 betterAccuracyPercentage;
@@ -221,18 +212,18 @@ void OsuScore::computeAccValue(const Beatmap &beatmap)
 
 	// Lots of arbitrary values from testing.
 	// Considering to use derivation from perfect accuracy in a probabilistic manner - assume normal distribution.
-	_accValue =
+	_accuracyValue =
 		pow(1.52163f, beatmap.DifficultyAttribute(_mods, Beatmap::OD)) * pow(betterAccuracyPercentage, 24) *
 		2.83f;
 
 	// Bonus for many hitcircles - it's harder to keep good accuracy up for longer.
-	_accValue *= std::min(1.15f, static_cast<f32>(pow(numHitObjectsWithAccuracy / 1000.0f, 0.3f)));
+	_accuracyValue *= std::min(1.15f, static_cast<f32>(pow(numHitObjectsWithAccuracy / 1000.0f, 0.3f)));
 
 	if ((_mods & EMods::Hidden) > 0)
-		_accValue *= 1.08f;
+		_accuracyValue *= 1.08f;
 
 	if ((_mods & EMods::Flashlight) > 0)
-		_accValue *= 1.02f;
+		_accuracyValue *= 1.02f;
 }
 
 void OsuScore::computeFlashlightValue(const Beatmap &beatmap)
@@ -249,7 +240,6 @@ void OsuScore::computeFlashlightValue(const Beatmap &beatmap)
 
 	_flashlightValue = std::pow(rawFlashlight, 2.0f) * 25.0f;
 
-	// Add an additional bonus for HDFL.
 	if ((_mods & EMods::Hidden) > 0)
 		_flashlightValue *= 1.3f;
 
@@ -259,10 +249,7 @@ void OsuScore::computeFlashlightValue(const Beatmap &beatmap)
 	if (_numMiss > 0)
 		_flashlightValue *= 0.97f * std::pow(1 - std::pow(_numMiss / static_cast<f32>(numTotalHits), 0.775f), std::pow(_numMiss, 0.875f));
 
-	// Combo scaling.
-	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
-	if (maxCombo > 0)
-		_flashlightValue *= std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	_flashlightValue *= getComboScalingFactor(beatmap);
 
 	// Account for shorter maps having a higher ratio of 0 combo/100 combo flashlight radius.
 	_flashlightValue *= 0.7f + 0.1f * std::min(1.0f, static_cast<f32>(numTotalHits) / 200.0f) +
@@ -274,4 +261,11 @@ void OsuScore::computeFlashlightValue(const Beatmap &beatmap)
 	_flashlightValue *= 0.98f + std::pow(beatmap.DifficultyAttribute(_mods, Beatmap::OD), 2.0f) / 2500.0f;
 }
 
+f32 OsuScore::getComboScalingFactor(const Beatmap &beatmap)
+{
+	float maxCombo = beatmap.DifficultyAttribute(_mods, Beatmap::MaxCombo);
+	if (maxCombo > 0)
+		return std::min(static_cast<f32>(pow(_maxCombo, 0.8f) / pow(maxCombo, 0.8f)), 1.0f);
+	return 1.0f;
+}
 PP_NAMESPACE_END


### PR DESCRIPTION
Applies the refactorings in https://github.com/ppy/osu/pull/16135.

I've tested that this doesn't change values across top 10000 users on all rulesets.