### PR TITLE
Reduce difficulty retrieval thread count

### DIFF
--- a/src/performance/Processor.cpp
+++ b/src/performance/Processor.cpp
@@ -65,7 +65,7 @@ Processor::Processor(EGamemode gamemode, const std::string& configFile)
 
 	queryBeatmapBlacklist();
 	queryBeatmapDifficultyAttributes();
-	queryAllBeatmapDifficulties(16);
+	queryAllBeatmapDifficulties(4);
 }
 
 Processor::~Processor()


### PR DESCRIPTION
Comparing `release` vs `master` shows three changes: https://github.com/ppy/osu-performance/compare/release?expand=1

- [Avoid using mysql 8 "rank" keyword in sql](https://github.com/ppy/osu-performance/commit/4080410be55cb889d96ea8c241eb155516727fcc)
- [Reduce step size](https://github.com/ppy/osu-performance/commit/7f72586cd45f975c68a5ee5d0df5cf0c392b7a2e)
- [Reduce difficulty retrieval thread count](https://github.com/ppy/osu-performance/commit/7b6e5a1e16ec998f5a88e7794e742e10e9b8e5bf)

The first two are already present in `master`, created via different commit hashes so the comparison doesn't properly de-dupe them:
https://github.com/ppy/osu-performance/blob/d4b8dee15f9f442b83c4f1475881b7e17f84cc74/src/performance/Processor.cpp#L1035-L1037
https://github.com/ppy/osu-performance/blob/d4b8dee15f9f442b83c4f1475881b7e17f84cc74/src/performance/Processor.cpp#L572-L574
But the last isn't:
https://github.com/ppy/osu-performance/blob/d4b8dee15f9f442b83c4f1475881b7e17f84cc74/src/performance/Processor.cpp#L67-L68