### PR TITLE
Expand DB port to 32-bits

### DIFF
--- a/include/pp/performance/Processor.h
+++ b/include/pp/performance/Processor.h
@@ -48,14 +48,14 @@ private:
 	struct
 	{
 		std::string MySqlMasterHost;
-		s16 MySqlMasterPort;
+		s32 MySqlMasterPort;
 		std::string MySqlMasterUsername;
 		std::string MySqlMasterPassword;
 		std::string MySqlMasterDatabase;
 
 		// By default, use the same database as master and slave.
 		std::string MySqlSlaveHost;
-		s16 MySqlSlavePort;
+		s32 MySqlSlavePort;
 		std::string MySqlSlaveUsername;
 		std::string MySqlSlavePassword;
 		std::string MySqlSlaveDatabase;

--- a/include/pp/shared/DatabaseConnection.h
+++ b/include/pp/shared/DatabaseConnection.h
@@ -15,7 +15,7 @@ class DatabaseConnection
 public:
 	DatabaseConnection(
 		std::string host,
-		s16 port,
+		s32 port,
 		std::string username,
 		std::string password,
 		std::string database
@@ -48,7 +48,7 @@ private:
 	std::recursive_mutex _dbMutex;
 
 	std::string _host;
-	s16 _port;
+	s32 _port;
 	std::string _username;
 	std::string _password;
 	std::string _database;

--- a/src/shared/DatabaseConnection.cpp
+++ b/src/shared/DatabaseConnection.cpp
@@ -7,7 +7,7 @@ PP_NAMESPACE_BEGIN
 
 DatabaseConnection::DatabaseConnection(
 	std::string host,
-	s16 port,
+	s32 port,
 	std::string username,
 	std::string password,
 	std::string database


### PR DESCRIPTION
I commonly expose my docker ports as 33306 to not clash with my local install, which overflows an int16.